### PR TITLE
add crawler for Commitstrip

### DIFF
--- a/comics/comics/commitstrip.py
+++ b/comics/comics/commitstrip.py
@@ -1,0 +1,23 @@
+from comics.aggregator.crawler import CrawlerBase, CrawlerImage
+from comics.core.comic_data import ComicDataBase
+
+class ComicData(ComicDataBase):
+    name = 'CommitStrip'
+    language = 'en'
+    url = 'http://www.commitstrip.com/en/'
+    start_date = '2012-02-22'
+    rights = 'CommitStrip/Etienne Issartial'
+
+
+class Crawler(CrawlerBase):
+    history_capable_days = 30
+    schedule = 'Mo,Tu,We,Th,Fr,Sa,Su'
+    time_zone = 'US/Pacific'
+
+    def crawl(self, pub_date):
+        feed = self.parse_feed('http://www.commitstrip.com/en/feed/')
+        for entry in feed.for_date(pub_date):
+            url = entry.content0.src('img[src*="/uploads/"]')
+            title = entry.title
+
+            return CrawlerImage(url, title)


### PR DESCRIPTION
Add crawler for Commitstrip. 
Some strips use unsupported characters, and I didn't find a standard for handling encoding errors in the docs. 
Running "python manage.py comics_getreleases -c commitstrip" still gets all comics without these characters
