### PR TITLE
update 'thegamercat' crawler to compensate for year-change in rss feed

### DIFF
--- a/comics/comics/thegamercat.py
+++ b/comics/comics/thegamercat.py
@@ -18,6 +18,9 @@ class Crawler(CrawlerBase):
     headers = {'User-Agent': 'Mozilla/4.0'}
 
     def crawl(self, pub_date):
+        # Compensating for website giving 1-year old dates
+        new_year = pub_date.year -1
+        pub_date = pub_date.replace(year=new_year)
         feed = self.parse_feed('http://thegamercat.com/feed/')
         for entry in feed.for_date(pub_date):
             url = entry.summary.src('img')


### PR DESCRIPTION
The Gamer Cat keeps on making trouble, now they are setting pubDate to be the current date minus one year
