### PR TITLE
Fix keyboard navigation in some browsers.

### DIFF
--- a/comics/static/js/comics.js
+++ b/comics/static/js/comics.js
@@ -11,7 +11,7 @@ var keyboardNavigation = (function () {
 
     var goToPreviousRelease = function () {
         var $previousRelease = $('.release').filter(function (index) {
-            return $(window).scrollTop() > getPosition($(this));
+            return $(window).scrollTop() > (getPosition($(this)) + 1);
         }).last();
 
         if ($previousRelease.length) {
@@ -23,7 +23,7 @@ var keyboardNavigation = (function () {
 
     var goToNextRelease = function () {
         var $nextRelease = $('.release').filter(function (index) {
-            return $(window).scrollTop() < getPosition($(this));
+            return $(window).scrollTop() < (getPosition($(this)) - 1);
         }).first();
 
         if ($nextRelease.length) {


### PR DESCRIPTION
On some versions of Firefox at least, j/k generates no movement.

Some may consider the fix a hack, but this passes basic local testing.

Currently at FF 55.0b2 on Debian.