### PR TITLE
Update crawlers for dagbladet.no

### DIFF
--- a/comics/comics/bestis.py
+++ b/comics/comics/bestis.py
@@ -12,8 +12,8 @@ class ComicData(ComicDataBase):
 
 
 class Crawler(DagbladetCrawlerBase):
-    history_capable_days = 14
-    schedule = "Mo,Tu,We,Th,Fr,Sa"
+    history_capable_days = 30
+    schedule = "Sa"
     time_zone = "Europe/Oslo"
 
     def crawl(self, pub_date):

--- a/comics/comics/dunce.py
+++ b/comics/comics/dunce.py
@@ -12,8 +12,8 @@ class ComicData(ComicDataBase):
 
 
 class Crawler(DagbladetCrawlerBase):
-    history_capable_date = "2017-03-16"
-    schedule = "Mo,Tu,We,Th,Fr"
+    history_capable_days = 30  # 3 saturdays
+    schedule = "Sa"
     time_zone = "Europe/Oslo"
 
     def crawl(self, pub_date):

--- a/comics/comics/fagprat.py
+++ b/comics/comics/fagprat.py
@@ -9,11 +9,10 @@ class ComicData(ComicDataBase):
     language = "no"
     url = "http://www.dagbladet.no/tegneserie/fagprat"
     rights = "Flu Hartberg"
+    active = False
 
 
 class Crawler(DagbladetCrawlerBase):
-    history_capable_days = 14
-    schedule = "Tu,Th,Sa"
     time_zone = "Europe/Oslo"
 
     def crawl(self, pub_date):

--- a/comics/comics/firekanta.py
+++ b/comics/comics/firekanta.py
@@ -9,11 +9,10 @@ class ComicData(ComicDataBase):
     language = "no"
     url = "http://www.dagbladet.no/tegneserie/firekanta"
     rights = "Nils Axle Kanten"
+    active = False
 
 
 class Crawler(DagbladetCrawlerBase):
-    history_capable_days = 14
-    schedule = "Mo,We,Fr"
     time_zone = "Europe/Oslo"
 
     def crawl(self, pub_date):

--- a/comics/comics/hjemmefronten.py
+++ b/comics/comics/hjemmefronten.py
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+from comics.aggregator.crawler import DagbladetCrawlerBase
+from comics.core.comic_data import ComicDataBase
+
+
+class ComicData(ComicDataBase):
+    name = "Intet nytt fra hjemmefronten"
+    language = "no"
+    url = "http://www.dagbladet.no/tegneserie/intetnyttfrahjemmefronten/"
+    rights = "Therese G. Eide"
+
+
+class Crawler(DagbladetCrawlerBase):
+    history_capable_days = 30
+    schedule = "Sa"
+    time_zone = "Europe/Oslo"
+
+    def crawl(self, pub_date):
+        return self.crawl_helper("intetnyttfrahjemmefronten", pub_date)

--- a/comics/comics/rutetid.py
+++ b/comics/comics/rutetid.py
@@ -9,11 +9,10 @@ class ComicData(ComicDataBase):
     language = "no"
     url = "http://www.dagbladet.no/tegneserie/rutetid/"
     rights = "Frode Øverli"
+    active = False
 
 
 class Crawler(DagbladetCrawlerBase):
-    history_capable_days = 14
-    schedule = "Mo,We,Fr"
     time_zone = "Europe/Oslo"
 
     def crawl(self, pub_date):


### PR DESCRIPTION
"Fagprat", "Firekanta" and "Rutetid" is no longer published.
"Bestis" and "Dunce" is only published on Saturdays.
New comic: "Intet nytt fra hjemmefronten"
