### PR TITLE
Mark crawlers as inactive

### DIFF
--- a/comics/comics/20px.py
+++ b/comics/comics/20px.py
@@ -8,6 +8,7 @@ class ComicData(ComicDataBase):
     url = "http://20px.com/"
     start_date = "2011-02-11"
     rights = "Angela"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/asofterworld.py
+++ b/comics/comics/asofterworld.py
@@ -8,6 +8,7 @@ class ComicData(ComicDataBase):
     url = "http://www.asofterworld.com/"
     start_date = "2003-02-07"
     rights = "Joey Comeau, Emily Horne"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/axecop.py
+++ b/comics/comics/axecop.py
@@ -8,11 +8,11 @@ class ComicData(ComicDataBase):
     url = "http://www.axecop.com/"
     start_date = "2010-01-02"
     rights = "Ethan Nicolle"
+    active = False
 
 
 class Crawler(CrawlerBase):
     history_capable_days = 60
-    schedule = "Tu"
     time_zone = "US/Pacific"
 
     headers = {"User-Agent": "Mozilla/4.0"}

--- a/comics/comics/blasternation.py
+++ b/comics/comics/blasternation.py
@@ -8,17 +8,11 @@ class ComicData(ComicDataBase):
     url = "http://www.blasternation.com/"
     start_date = "2011-01-27"
     rights = "Leslie Brown & Brad Brown"
+    active = False
 
 
 class Crawler(CrawlerBase):
-    history_capable_days = 90
-    schedule = "We,Fr,Su"
     time_zone = "US/Eastern"
 
     def crawl(self, pub_date):
-        feed = self.parse_feed("http://www.blasternation.com/rss.php")
-        for entry in feed.for_date(pub_date):
-            page = self.parse_page(entry.link)
-            url = page.src("img#cc-comic")
-            title = entry.title.replace("Blaster Nation - ", "")
-            return CrawlerImage(url, title)
+        pass

--- a/comics/comics/cardboardcrack.py
+++ b/comics/comics/cardboardcrack.py
@@ -8,6 +8,7 @@ class ComicData(ComicDataBase):
     url = "http://cardboard-crack.com/"
     start_date = "2013-03-01"
     rights = "Magic Addict"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/completelyseriouscomics.py
+++ b/comics/comics/completelyseriouscomics.py
@@ -8,6 +8,7 @@ class ComicData(ComicDataBase):
     url = "http://completelyseriouscomics.com/"
     start_date = "2010-12-30"
     rights = "Jesse"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/criticalmiss.py
+++ b/comics/comics/criticalmiss.py
@@ -1,4 +1,4 @@
-from comics.aggregator.crawler import CrawlerBase, CrawlerImage
+from comics.aggregator.crawler import CrawlerBase
 from comics.core.comic_data import ComicDataBase
 
 
@@ -11,22 +11,11 @@ class ComicData(ComicDataBase):
     )
     start_date = "2010-05-18"
     rights = "Cory Rydell & Grey Carter"
+    active = False
 
 
 class Crawler(CrawlerBase):
-    history_capable_days = 200
-    schedule = "Tu,Fr"
     time_zone = "US/Pacific"
 
     def crawl(self, pub_date):
-        feed = self.parse_feed(
-            "http://rss.escapistmagazine.com"
-            "/articles/comicsandcosplay/comics/critical-miss"
-        )
-        for entry in feed.for_date(pub_date):
-            page = self.parse_page(entry.link)
-            url = page.src('.body img[src$=".png"]')
-            title = entry.title
-            if title is not None:
-                title = title.replace("Critical Miss: ", "")
-            return CrawlerImage(url, title)
+        pass

--- a/comics/comics/crookedgremlins.py
+++ b/comics/comics/crookedgremlins.py
@@ -8,6 +8,7 @@ class ComicData(ComicDataBase):
     url = "http://www.crookedgremlins.com/"
     start_date = "2008-04-01"
     rights = "Carter Fort and Paul Lucci"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/ctrlaltdelsillies.py
+++ b/comics/comics/ctrlaltdelsillies.py
@@ -1,4 +1,4 @@
-from comics.aggregator.crawler import CrawlerBase, CrawlerImage
+from comics.aggregator.crawler import CrawlerBase
 from comics.core.comic_data import ComicDataBase
 
 
@@ -8,19 +8,9 @@ class ComicData(ComicDataBase):
     url = "http://www.cad-comic.com/sillies/"
     start_date = "2008-06-27"
     rights = "Tim Buckley"
+    active = False
 
 
 class Crawler(CrawlerBase):
-    history_capable_date = "2008-06-27"
-    schedule = None
-    time_zone = "US/Eastern"
-
-    # Without User-Agent set, the server returns empty responses
-    headers = {"User-Agent": "Mozilla/4.0"}
-
     def crawl(self, pub_date):
-        page = self.parse_page(
-            "http://www.cad-comic.com/sillies/%s" % pub_date.strftime("%Y%m%d")
-        )
-        url = page.src('img[src*="/comics/"]')
-        return CrawlerImage(url)
+        pass

--- a/comics/comics/drmcninja.py
+++ b/comics/comics/drmcninja.py
@@ -8,6 +8,7 @@ class ComicData(ComicDataBase):
     url = "http://drmcninja.com/"
     start_date = "2004-08-03"
     rights = "Christopher Hastings"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/fanboys.py
+++ b/comics/comics/fanboys.py
@@ -1,4 +1,4 @@
-from comics.aggregator.crawler import CrawlerBase, CrawlerImage
+from comics.aggregator.crawler import CrawlerBase
 from comics.core.comic_data import ComicDataBase
 
 

--- a/comics/comics/fanboys.py
+++ b/comics/comics/fanboys.py
@@ -8,20 +8,9 @@ class ComicData(ComicDataBase):
     url = "http://www.fanboys-online.com/"
     start_date = "2006-04-19"
     rights = "Scott Dewitt"
+    active = False
 
 
 class Crawler(CrawlerBase):
-    history_capable_days = 180
-    schedule = "Mo,Fr"
-    time_zone = "US/Eastern"
-
     def crawl(self, pub_date):
-        feed = self.parse_feed("http://www.fanboys-online.com/rss.php")
-        for entry in feed.for_date(pub_date):
-            title = entry.title.replace("Fanboys - ", "")
-            page = self.parse_page(entry.link)
-            url = page.src("img#comic")
-            if not url:
-                continue
-            url = url.replace(" ", "%20")
-            return CrawlerImage(url, title)
+        pass

--- a/comics/comics/fatawesome.py
+++ b/comics/comics/fatawesome.py
@@ -1,4 +1,4 @@
-from comics.aggregator.crawler import CrawlerBase, CrawlerImage
+from comics.aggregator.crawler import CrawlerBase
 from comics.core.comic_data import ComicDataBase
 
 
@@ -8,18 +8,9 @@ class ComicData(ComicDataBase):
     url = "http://www.fatawesome.com/"
     start_date = "2014-09-16"
     rights = "James Craig"
+    active = False
 
 
 class Crawler(CrawlerBase):
-    history_capable_date = "2014-09-16"
-    time_zone = "US/Eastern"
-
     def crawl(self, pub_date):
-        feed = self.parse_feed("http://www.fatawesome.com/feed/")
-        for entry in feed.for_date(pub_date):
-            if "Comics" not in entry.tags:
-                continue
-            url = entry.content0.src("img")
-            title = entry.title
-            text = entry.content0.alt("img")
-            return CrawlerImage(url, title, text)
+        pass

--- a/comics/comics/gunshow.py
+++ b/comics/comics/gunshow.py
@@ -8,6 +8,7 @@ class ComicData(ComicDataBase):
     url = "http://www.gunshowcomic.com/"
     start_date = "2008-09-04"
     rights = '"Lord KC Green"'
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/icanbarelydraw.py
+++ b/comics/comics/icanbarelydraw.py
@@ -8,6 +8,7 @@ class ComicData(ComicDataBase):
     url = "http://www.icanbarelydraw.com/"
     start_date = "2011-08-05"
     rights = "Group effort, CC BY-NC-ND 3.0"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/ikkesaro.py
+++ b/comics/comics/ikkesaro.py
@@ -7,6 +7,7 @@ class ComicData(ComicDataBase):
     language = "no"
     url = "http://ikkesaro.nettserier.no/"
     rights = "Ladder"
+    active = False
 
 
 class Crawler(NettserierCrawlerBase):

--- a/comics/comics/manlyguys.py
+++ b/comics/comics/manlyguys.py
@@ -8,6 +8,7 @@ class ComicData(ComicDataBase):
     url = "http://thepunchlineismachismo.com/"
     start_date = "2005-05-29"
     rights = "Kelly Turnbull, CC BY-NC-SA 3.0"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/mysticrevolution.py
+++ b/comics/comics/mysticrevolution.py
@@ -8,6 +8,7 @@ class ComicData(ComicDataBase):
     url = "http://mysticrevolution.keenspot.com/"
     start_date = "2004-01-01"
     rights = "Jennifer Brazas"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/notinventedhere.py
+++ b/comics/comics/notinventedhere.py
@@ -8,11 +8,11 @@ class ComicData(ComicDataBase):
     url = "http://notinventedhe.re/"
     start_date = "2009-09-21"
     rights = "Bill Barnes and Paul Southworth"
+    active = False
 
 
 class Crawler(CrawlerBase):
     history_capable_date = "2009-09-21"
-    schedule = "Tu,Th"
     time_zone = "US/Pacific"
 
     def crawl(self, pub_date):

--- a/comics/comics/partiallyclips.py
+++ b/comics/comics/partiallyclips.py
@@ -1,4 +1,4 @@
-from comics.aggregator.crawler import CrawlerBase, CrawlerImage
+from comics.aggregator.crawler import CrawlerBase
 from comics.core.comic_data import ComicDataBase
 
 
@@ -8,19 +8,9 @@ class ComicData(ComicDataBase):
     url = "http://partiallyclips.com/"
     start_date = "2002-01-01"
     rights = "Robert T. Balder"
+    active = False
 
 
 class Crawler(CrawlerBase):
-    history_capable_days = 32
-    schedule = "Tu"
-    time_zone = "US/Eastern"
-
     def crawl(self, pub_date):
-        feed = self.parse_feed("http://partiallyclips.com/feed/")
-        for entry in feed.for_date(pub_date):
-            url = entry.summary.src("img")
-            if not url:
-                continue
-            url = url.replace("comics-rss", "comics")
-            title = entry.title.split(" - ")[0]
-            return CrawlerImage(url, title)
+        pass

--- a/comics/comics/seemikedraw.py
+++ b/comics/comics/seemikedraw.py
@@ -7,11 +7,13 @@ class ComicData(ComicDataBase):
     language = "en"
     url = "http://mikejacobsen.tumblr.com/"
     start_date = "2007-07-31"
+    end_date = '2017-04-06'
     rights = "Mike Jacobsen"
+    active = False
 
 
 class Crawler(CrawlerBase):
-    history_capable_days = 180
+    history_capable_date = '2014-05-06'
     time_zone = "Australia/Sydney"
 
     def crawl(self, pub_date):

--- a/comics/comics/seemikedraw.py
+++ b/comics/comics/seemikedraw.py
@@ -7,13 +7,13 @@ class ComicData(ComicDataBase):
     language = "en"
     url = "http://mikejacobsen.tumblr.com/"
     start_date = "2007-07-31"
-    end_date = '2017-04-06'
+    end_date = "2017-04-06"
     rights = "Mike Jacobsen"
     active = False
 
 
 class Crawler(CrawlerBase):
-    history_capable_date = '2014-05-06'
+    history_capable_date = "2014-05-06"
     time_zone = "Australia/Sydney"
 
     def crawl(self, pub_date):

--- a/comics/comics/spaceavalanche.py
+++ b/comics/comics/spaceavalanche.py
@@ -8,6 +8,7 @@ class ComicData(ComicDataBase):
     url = "http://www.spaceavalanche.com/"
     start_date = "2009-02-02"
     rights = "Eoin Ryan"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/stickydillybuns.py
+++ b/comics/comics/stickydillybuns.py
@@ -10,6 +10,7 @@ class ComicData(ComicDataBase):
     url = "http://www.stickydillybuns.com/"
     start_date = "2013-01-07"
     rights = "G. Lagace"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/subnormality.py
+++ b/comics/comics/subnormality.py
@@ -9,7 +9,9 @@ class ComicData(ComicDataBase):
     language = "en"
     url = "http://www.viruscomix.com/subnormality.html"
     start_date = "2007-01-01"
+    end_date = '2019-06-07'
     rights = "Winston Rowntree"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/subnormality.py
+++ b/comics/comics/subnormality.py
@@ -9,7 +9,7 @@ class ComicData(ComicDataBase):
     language = "en"
     url = "http://www.viruscomix.com/subnormality.html"
     start_date = "2007-01-01"
-    end_date = '2019-06-07'
+    end_date = "2019-06-07"
     rights = "Winston Rowntree"
     active = False
 

--- a/comics/comics/supereffective.py
+++ b/comics/comics/supereffective.py
@@ -8,6 +8,7 @@ class ComicData(ComicDataBase):
     url = "http://www.vgcats.com/super/"
     start_date = "2008-04-23"
     rights = "Scott Ramsoomair"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/thedreamer.py
+++ b/comics/comics/thedreamer.py
@@ -7,6 +7,7 @@ class ComicData(ComicDataBase):
     language = "en"
     url = "http://thedreamercomic.com/"
     rights = "Lora Innes"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/thegutters.py
+++ b/comics/comics/thegutters.py
@@ -9,6 +9,7 @@ class ComicData(ComicDataBase):
     language = "en"
     url = "http://the-gutters.com/"
     rights = "Blind Ferret Entertainment"
+    active = False
 
 
 class Crawler(CrawlerBase):

--- a/comics/comics/utensokker.py
+++ b/comics/comics/utensokker.py
@@ -9,6 +9,7 @@ class ComicData(ComicDataBase):
     url = "http://utensokker.nettserier.no/"
     start_date = "2009-07-14"
     rights = "Bjørnar Grandalen"
+    active = False
 
 
 class Crawler(NettserierCrawlerBase):

--- a/comics/comics/wyyrd.py
+++ b/comics/comics/wyyrd.py
@@ -8,6 +8,7 @@ class ComicData(ComicDataBase):
     url = "http://wyyrd.nettserier.no/"
     start_date = "2008-01-14"
     rights = "Gard Robot Helset"
+    active = False
 
 
 class Crawler(NettserierCrawlerBase):

--- a/comics/comics/yamac.py
+++ b/comics/comics/yamac.py
@@ -1,4 +1,4 @@
-from comics.aggregator.crawler import CrawlerBase, CrawlerImage
+from comics.aggregator.crawler import CrawlerBase
 from comics.core.comic_data import ComicDataBase
 
 

--- a/comics/comics/yamac.py
+++ b/comics/comics/yamac.py
@@ -8,6 +8,7 @@ class ComicData(ComicDataBase):
     url = "http://strawberry-pie.net/SA/"
     start_date = "2009-07-01"
     rights = "bubble"
+    active = False
 
 
 class Crawler(CrawlerBase):
@@ -15,11 +16,4 @@ class Crawler(CrawlerBase):
     time_zone = "US/Pacific"
 
     def crawl(self, pub_date):
-        feed = self.parse_feed("http://strawberry-pie.net/SA/?feed=rss2")
-        for entry in feed.for_date(pub_date):
-            if "comic" not in entry.tags:
-                continue
-            url = entry.summary.src("img")
-            url = url.replace("comics-rss", "comics")
-            title = entry.title
-            return CrawlerImage(url, title)
+        pass


### PR DESCRIPTION
A lot of crawlers are no longer active, and some cause errors when crawling. Crawlers with a working site or feed are marked as inactive with the crawler code intact. Where the site or feed is gone, the crawler code is removed.