### PR TITLE
Add history capability for comics published at nettserier.no

### DIFF
--- a/comics/aggregator/crawler.py
+++ b/comics/aggregator/crawler.py
@@ -325,10 +325,15 @@ class NettserierCrawlerBase(CrawlerBase):
                     return  # No previous comic
                 page, comic_date = self.get_page(previous_link[0])
             elif pub_date == comic_date:  # Correct date found
-                # Get comic-text div which contains title and text for the comic
-                comic_text = page.root.xpath('//div[@class="comic-text"]')[0]
-                title = comic_text.find("h4").text
-                text = comic_text.find("p").text
+                # comic-text div which contains title and text for the comic
+                title = page.text("div.comic-text h4")
+                text = page.text("div.comic-text p", allow_multiple=True)
+
+                if text[0].find("Published") > -1:
+                    text = None
+                else:
+                    text = text[0]
+
                 # Get comic image
                 url = page.src('img[src*="/_ns/files"]')
                 return CrawlerImage(url, title, text)

--- a/comics/aggregator/crawler.py
+++ b/comics/aggregator/crawler.py
@@ -336,4 +336,4 @@ class NettserierCrawlerBase(CrawlerBase):
 
         # Get comic image
         url = page.src('img[src*="/_ns/files"]')
-            return CrawlerImage(url, title, text)
+        return CrawlerImage(url, title, text)

--- a/comics/aggregator/crawler.py
+++ b/comics/aggregator/crawler.py
@@ -315,23 +315,25 @@ class NettserierCrawlerBase(CrawlerBase):
         url = "https://nettserier.no/%s/" % short_name
         page, comic_date = self.get_page(url)
 
-        while pub_date <= comic_date:
+        while pub_date < comic_date:
             # Wanted date is earlier than the current, get previous page
-            if pub_date < comic_date:
-                previous_link = page.root.xpath('//li[@class="prev"]/a/@href')
-                if not previous_link:
-                    return  # No previous comic
-                page, comic_date = self.get_page(previous_link[0])
-            elif pub_date == comic_date:  # Correct date found
-                # comic-text div which contains title and text for the comic
-                title = page.text("div.comic-text h4")
-                text = page.text("div.comic-text p", allow_multiple=True)
+            previous_link = page.root.xpath('//li[@class="prev"]/a/@href')
+            if not previous_link:
+                return  # No previous comic
+            page, comic_date = self.get_page(previous_link[0])
 
-                if text[0].find("Published") > -1:
-                    text = None
-                else:
-                    text = text[0]
+        if pub_date != comic_date:
+            return  # Correct date not found
 
-                # Get comic image
-                url = page.src('img[src*="/_ns/files"]')
-                return CrawlerImage(url, title, text)
+        # comic-text div which contains title and text for the comic
+        title = page.text("div.comic-text h4")
+        text = page.text("div.comic-text p", allow_multiple=True)
+
+        if text[0].find("Published") > -1:
+            text = None
+        else:
+            text = text[0]
+
+        # Get comic image
+        url = page.src('img[src*="/_ns/files"]')
+            return CrawlerImage(url, title, text)

--- a/comics/aggregator/crawler.py
+++ b/comics/aggregator/crawler.py
@@ -307,9 +307,7 @@ class NettserierCrawlerBase(CrawlerBase):
         if url not in self.page_cache:
             page = self.parse_page(url)
             page_date = page.text('p[class="comic-pubtime"]')
-            date = self.string_to_date(
-                page_date, "Published %Y-%m-%d %H:%M:%S"
-            )
+            date = self.string_to_date(page_date, "Published %Y-%m-%d %H:%M:%S")
             self.page_cache[url] = [page, date]
         return self.page_cache[url]
 


### PR DESCRIPTION
nettserier.no has no way to fetch a specific date, the only option is a link to the previous release.
The crawler loops through all the pages till it reaches the requested release.
All pages are cached in case we are crawling multiple days.