### PR TITLE
Raise exception from feedparser

### DIFF
--- a/comics/aggregator/crawler.py
+++ b/comics/aggregator/crawler.py
@@ -4,7 +4,7 @@ import json
 import socket
 import time
 import urllib2
-import xml.sax._exceptions
+import xml
 
 from django.utils import timezone
 
@@ -111,7 +111,7 @@ class CrawlerBase(object):
             raise CrawlerHTTPError(release.identifier, "BadStatusLine")
         except socket.error as error:
             raise CrawlerHTTPError(release.identifier, error)
-        except xml.sax._exceptions.SAXException as error:
+        except xml.sax.SAXException as error:
             raise CrawlerHTTPError(release.identifier, str(error))
 
         if not results:

--- a/comics/aggregator/feedparser.py
+++ b/comics/aggregator/feedparser.py
@@ -11,6 +11,8 @@ from comics.aggregator.lxmlparser import LxmlParser
 class FeedParser(object):
     def __init__(self, url):
         self.raw_feed = feedparser.parse(url)
+        if 'bozo_exception' in self.raw_feed:
+            raise self.raw_feed['bozo_exception']
         self.encoding = None
         if hasattr(self.raw_feed, "encoding") and self.raw_feed.encoding:
             self.encoding = self.raw_feed.encoding

--- a/comics/aggregator/feedparser.py
+++ b/comics/aggregator/feedparser.py
@@ -11,8 +11,8 @@ from comics.aggregator.lxmlparser import LxmlParser
 class FeedParser(object):
     def __init__(self, url):
         self.raw_feed = feedparser.parse(url)
-        if 'bozo_exception' in self.raw_feed:
-            raise self.raw_feed['bozo_exception']
+        if "bozo_exception" in self.raw_feed:
+            raise self.raw_feed["bozo_exception"]
         self.encoding = None
         if hasattr(self.raw_feed, "encoding") and self.raw_feed.encoding:
             self.encoding = self.raw_feed.encoding


### PR DESCRIPTION
When there is an error during xml parsing in feedparser the SAXException is caught and returned with the data. I added a check for the exception and re-raise it, making the handling added in 70b4c4b1d471ff59e3ad0a9aecd4189087d068a8 work as intended.
I also changed the import path to avoid importing from a private class.