### PR TITLE
Docs updates

### DIFF
--- a/docs/bootstrapping.rst
+++ b/docs/bootstrapping.rst
@@ -1,0 +1,84 @@
+Bootstrapping
+=============
+
+Once you've installed Comics, you need to create the database and create the
+initial users and comics.
+
+To get Comics to a state useful for testing of new crawlers and personal
+usage, the following steps are all that is needed.
+
+
+Create database
+---------------
+
+A file-based SQLite database will be used, unless you have configured another
+database, like PostgreSQL.
+
+To create the database and database schema, open a terminal, go to top level
+directory in your checkout of the Comics repo, where you'll find the file
+``manage.py``, and run::
+
+    python manage.py migrate
+
+
+Create first user
+-----------------
+
+When ``migrate`` has finished, create a superuser by running::
+
+    python manage.py createsuperuser
+
+
+Add comics
+----------
+
+Then we need to seed the database with information on what comics to crawl.
+E.g. to add the *XKCD* comic from ``comics/comics/comics/xkcd.py``, run::
+
+    python manage.py comics_addcomics -c xkcd
+
+Optionally, you can add all available active comics to the database::
+
+    python manage.py comics_addcomics -c all
+
+
+Get comic releases
+------------------
+
+Next, we need to get hold of some comic releases, so we will crawl the web for
+them. This will get today's releases for all added comics::
+
+    python manage.py comics_getreleases
+
+To get the release for a specific added comics, you can filter with
+:option:`--comic` or :option:`-c`::
+
+    python manage.py comics_getreleases -c xkcd
+
+To get releases for a range of days, you can specify a date range with
+:option:`--from` or :option:`-f` and :option:`--to` or :option:`-t`. Both
+defaults to today, so you can leave the end of the range out::
+
+    python manage.py comics_getreleases -f 2011-11-11
+
+
+Development web server
+----------------------
+
+Finally, to be able to browse the comic releases we have aggregated, start the
+Django development web server by running::
+
+    python manage.py runserver
+
+If you now point your web browser at http://localhost:8000/ you will be able to
+browse all available comics. If you created a superuser above, you can log in
+at http://localhost:8000/admin/ to do simple administration tasks, like
+removing comics or releases.
+
+
+More options
+------------
+
+All of the ``manage.py`` commands got more options available. Add the
+:option:`--help` argument to any of the commands to get a full listing of the
+available options.

--- a/docs/bootstrapping.rst
+++ b/docs/bootstrapping.rst
@@ -51,12 +51,12 @@ them. This will get today's releases for all added comics::
     python manage.py comics_getreleases
 
 To get the release for a specific added comics, you can filter with
-:option:`--comic` or :option:`-c`::
+``--comic`` or ``-c``::
 
     python manage.py comics_getreleases -c xkcd
 
 To get releases for a range of days, you can specify a date range with
-:option:`--from` or :option:`-f` and :option:`--to` or :option:`-t`. Both
+``--from`` or ``-f`` and ``--to`` or ``-t``. Both
 defaults to today, so you can leave the end of the range out::
 
     python manage.py comics_getreleases -f 2011-11-11
@@ -80,5 +80,5 @@ More options
 ------------
 
 All of the ``manage.py`` commands got more options available. Add the
-:option:`--help` argument to any of the commands to get a full listing of the
+``--help`` argument to any of the commands to get a full listing of the
 available options.

--- a/docs/crawlers.rst
+++ b/docs/crawlers.rst
@@ -3,9 +3,9 @@ Creating crawlers
 *****************
 
 For each comic Comics is aggregating, we need to create a crawler. At the
-time of writing, about 100 crawlers are available in the
-``comics/comics/comics/`` directory. They serve as a great source for learning
-how to write new crawlers for Comics.
+time of writing, more than 200 crawlers are available in the
+``comics/comics/`` directory. They serve as a great source for learning how
+to write new crawlers for Comics.
 
 
 A crawler example
@@ -24,7 +24,7 @@ implementation itself.
     class ComicData(ComicDataBase):
         name = 'xkcd'
         language = 'en'
-        url = 'http://www.xkcd.com/'
+        url = 'https://www.xkcd.com/'
         start_date = '2005-05-29'
         rights = 'Randall Munroe, CC BY-NC 2.5'
 
@@ -34,7 +34,7 @@ implementation itself.
         time_zone = 'US/Eastern'
 
         def crawl(self, pub_date):
-            feed = self.parse_feed('http://www.xkcd.com/rss.xml')
+            feed = self.parse_feed('https://www.xkcd.com/rss.xml')
             for entry in feed.for_date(pub_date):
                 url = entry.summary.src('img[src*="/comics/"]')
                 title = entry.title
@@ -189,12 +189,13 @@ This means that you must always supply an URL, and that you can supply a
 For some crawlers, this is all you need. If the image URL is predictable and
 based upon the ``pub_date`` in some way, just create the URL with the help
 of `Python's strftime documentation
-<http://docs.python.org/library/datetime.html#strftime-behavior>`_, and return
-it wrapped in a :class:`CrawlerImage`::
+<https://docs.python.org/2.7/library/datetime.html#strftime-behavior>`_, and
+return it wrapped in a :class:`CrawlerImage`::
 
     def crawl(self, pub_date):
         url = 'http://www.example.com/comics/%s.png' % (
-            pub_date.strftime('%Y-%m-%d'),)
+            pub_date.strftime('%Y-%m-%d'),
+        )
         return CrawlerImage(url)
 
 Though, for most crawlers, some interaction with RSS or Atom feeds or web pages
@@ -339,7 +340,7 @@ class ``foo`` red, and all elements with the ID ``bar`` which is contained in
 
 .. code-block:: css
 
-    h1.foo { color red; }
+    h1.foo { color: red; }
     h1 #bar { color: blue; }
 
 In CSS3, the power of CSS selectors have been greatly increased by the addition

--- a/docs/crawlers.rst
+++ b/docs/crawlers.rst
@@ -1,6 +1,6 @@
-*********************
-Creating new crawlers
-*********************
+*****************
+Creating crawlers
+*****************
 
 For each comic Comics is aggregating, we need to create a crawler. At the
 time of writing, about 100 crawlers are available in the

--- a/docs/crawlers.rst
+++ b/docs/crawlers.rst
@@ -2,10 +2,10 @@
 Creating new crawlers
 *********************
 
-For each comic *comics* is aggregating, we need to create a crawler. At the
+For each comic Comics is aggregating, we need to create a crawler. At the
 time of writing, about 100 crawlers are available in the
 ``comics/comics/comics/`` directory. They serve as a great source for learning
-how to write new crawlers for *comics*.
+how to write new crawlers for Comics.
 
 
 A crawler example
@@ -207,7 +207,7 @@ Returning multiple images for a single comic release
 
 Some comics got releases with multiple images, and thus returning a single
 :class:`CrawlerImage` will not be enough for you. For situations like these,
-*comics* lets you return a list of :class:`CrawlerImage` objects from
+Comics lets you return a list of :class:`CrawlerImage` objects from
 :meth:`Crawler.crawl()`. The list should be ordered in the same way as the
 comic is meant to be read, with the first frame as the first element in the
 list. If the comic release got a ``title``, add it to the first
@@ -407,7 +407,7 @@ the image URL::
 Feed :class:`Entry` API
 -----------------------
 
-The *comics* feed parser is really a combination of the popular `feedparser
+The Comics feed parser is really a combination of the popular `feedparser
 <http://www.feedparser.org/>`_ library and :class:`LxmlParser
 <comics.aggregator.lxmlparser.LxmlParser>`. It can do anything *feedparser* can
 do, and in addition you can use the :class:`LxmlParser
@@ -456,8 +456,8 @@ Testing your new crawler
 When the first version of you crawler is complete, it's time to test it.
 
 The file name is important, as it is used as the comic's slug. This means that
-it must be unique within the *comics* installation, and that it is used in the
-URLs *comics* will serve the comic at. For this example, we call the crawler
+it must be unique within the Comics installation, and that it is used in the
+URLs Comics will serve the comic at. For this example, we call the crawler
 file ``foo.py``. The file must be placed in the ``comics/comics/comics/``
 directory, and will be available in Python as ``comics.comics.foo``.
 
@@ -465,8 +465,8 @@ directory, and will be available in Python as ``comics.comics.foo``.
 Loading :class:`ComicData` for your new comic
 ---------------------------------------------
 
-For *comics* to know about your new crawler, you need to load the comic meta
-data into *comics*'s database. To do so, we run the ``comics_addcomics``
+For Comics to know about your new crawler, you need to load the comic meta
+data into Comics' database. To do so, we run the ``comics_addcomics``
 command::
 
     python manage.py comics_addcomics -c foo
@@ -505,12 +505,12 @@ For a full overview of ``comics_getreleases`` options, run::
     python manage.py comics_getreleases --help
 
 
-Submitting your new crawler for inclusion in *comics*
+Submitting your new crawler for inclusion in Comics
 =====================================================
 
 When your crawler is working properly, you may submit it for inclusion in
-*comics*. You should fork *comics* at `GitHub
+Comics. You should fork Comics at `GitHub
 <http://github.com/jodal/comics>`_, commit your new crawler to your own fork,
 and send me a *pull request* through GitHub.
 
-All contributions must be granted under the same license as *comics* itself.
+All contributions must be granted under the same license as Comics itself.

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -2,14 +2,14 @@
 Deployment
 **********
 
-The following example documents *one way* to deploy *comics*. As *comics* is a
+The following example documents *one way* to deploy Comics. As Comics is a
 standard Django project with an additional batch job for crawling, it may be
 deployed in just about any way a Django project may be deployed. Please refer
 to `Django's deployment documentation
 <https://docs.djangoproject.com/en/dev/howto/deployment/>`_ for further
 details.
 
-In the following examples we assume that we are deploying *comics* at
+In the following examples we assume that we are deploying Comics at
 http://comics.example.com/, using Apache, mod_wsgi, and PostgreSQL. The Django
 application and batch job is both running as the user ``comics-user``. The
 static media files, like comic images, are served from
@@ -19,7 +19,7 @@ http://comics.example.com/media/, but may also be served from a different host.
 Database
 ========
 
-*comics* should theoretically work with any database supported by Django.
+Comics should theoretically work with any database supported by Django.
 Though, development is mostly done on SQLite and PostgreSQL. For production
 use, PostgreSQL is the recommended choice.
 
@@ -69,7 +69,7 @@ Example ``.env``
 ================
 
 To change settings, you should not change the settings files shipped with
-*comics*, but instead override the settings in the apps environment or in the
+Comics, but instead override the settings in the apps environment or in the
 file ``comics/.env``.  Even if you do not want to override any default
 settings, you must at least set ``DJANGO_SECRET_KEY`` and most probably your
 database settings. A full set of environment variables for a production
@@ -129,7 +129,7 @@ One way is to use ``cron`` e.g. by placing the following in
     1 * * * * comics-user python /path/to/comics/manage.py comics_getreleases -v0
     1 3 * * * comics-user python /path/to/comics/manage.py clear_expired_invitations -v0
 
-If you have installed *comics*' dependencies in a virtualenv instead of
+If you have installed Comics' dependencies in a virtualenv instead of
 globally, the cronjob must also activate the virtualenv. This can be done by
 using the ``python`` interpreter from the virtualenv:
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -2,20 +2,20 @@
 Development
 ***********
 
-*comics* development is coordinated through `GitHub <http://github.com/>`_.
+Comics development is coordinated through `GitHub <http://github.com/>`_.
 
 
 How to contribute
 =================
 
-The easiest way to contribute to *comics* is to register as a user at GitHub,
+The easiest way to contribute to Comics is to register as a user at GitHub,
 fork `the comics project <http://github.com/jodal/comics>`_, and start hacking.
-To get your changes back into *comics*' mainline, send a pull request to `jodal
+To get your changes back into Comics' mainline, send a pull request to `jodal
 at GitHub <http://github.com/jodal>`_. Patches accompanied by tests and
-documentation gives +5 karma and kudos. When hacking on *comics*, please follow
+documentation gives +5 karma and kudos. When hacking on Comics, please follow
 the code style and commit guidelines below.
 
-All contributions must be granted under the same license as *comics* itself.
+All contributions must be granted under the same license as Comics itself.
 
 
 Code style
@@ -89,7 +89,7 @@ Commit guidelines
 Data model
 ==========
 
-*comics*' data model is very simple. The :mod:`comics.core` app consists of
+Comics' data model is very simple. The :mod:`comics.core` app consists of
 three models; :class:`Comic <comics.core.models.Comic>`, :class:`Release
 <comics.core.models.Release>`, and :class:`Image <comics.core.models.Image>`.
 The :mod:`comics.accounts` app adds a :class:`UserProfile
@@ -115,8 +115,8 @@ the following command:
 Running tests
 =============
 
-*comics* got some tests, but far from full test coverage. If you write new or
-improved tests for *comics*' functionality it will be greatly appreciated.
+Comics got some tests, but far from full test coverage. If you write new or
+improved tests for Comics' functionality it will be greatly appreciated.
 
 To run unit tests::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,25 +11,25 @@ Python file with some metadata and a few lines of code. To make crawler
 development easy, Comics comes with both documentation and powerful APIs for
 crawling web sites and feeds.
 
-
-Contents
---------
-
 .. toctree::
-    :maxdepth: 3
+    :maxdepth: 2
+    :caption: Setup
 
     installation
+    bootstrapping
     deployment
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Reference
+
     crawlers
     webservice
+
+.. toctree::
+    :maxdepth: 2
+    :caption: About
+
     development
     authors
     changes
-
-
-Indices and tables
-------------------
-
-- :ref:`genindex`
-- :ref:`modindex`
-- :ref:`search`

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,18 +1,18 @@
 Installation
 ************
 
-First of all, *comics* is just a `Django <https://www.djangoproject.com/>`_
-application. Thus, if there are details not outlined in *comics*' own docs,
+First of all, Comics is just a `Django <https://www.djangoproject.com/>`_
+application. Thus, if there are details not outlined in Comics' own docs,
 you'll probably find the answer in Django's docs. For example, database
 settings are mentioned on this page, but no details are given, as we're just
 talking about Django's database settings. Django got better docs for their
 database settings than we could ever write, so please refer to Django's docs.
 
 
-Get *comics*
+Get Comics
 ============
 
-You can get hold of *comics* in two ways:
+You can get hold of Comics in two ways:
 
 - Download the lastest release from https://github.com/jodal/comics/tags and
   unpack it.
@@ -56,7 +56,7 @@ sure that the WSGI file and the cronjob activate the virtualenv.
 Minimum dependencies
 --------------------
 
-The absolute minimum requirements for getting *comics* up and running are
+The absolute minimum requirements for getting Comics up and running are
 documented in the file ``requirements.txt``:
 
 .. literalinclude:: ../requirements.txt
@@ -80,10 +80,10 @@ are listed in the file ``requirements-dev.txt``:
 .. literalinclude:: ../requirements-dev.txt
 
 
-Run *comics*
+Run Comics
 ============
 
-To get *comics* to a state useful for testing of new crawlers and personal
+To get Comics to a state useful for testing of new crawlers and personal
 usage, the following steps are all that is needed.
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,27 +9,27 @@ talking about Django's database settings. Django got better docs for their
 database settings than we could ever write, so please refer to Django's docs.
 
 
-Get Comics
-============
+Get release
+===========
 
 You can get hold of Comics in two ways:
 
-- Download the lastest release from https://github.com/jodal/comics/tags and
-  unpack it.
+- Download the lastest release from https://github.com/jodal/comics/releases.
 
 - Clone the Git repository. You can do so by running::
 
       git clone https://github.com/jodal/comics.git
+
+  You'll then have the latest development snapshot in the ``main`` branch::
+
       cd comics/
 
-  You'll then find the current stable/maintenance version in the ``master``
-  branch::
+  If you want to run a specific release, they are available as tags in the
+  Git repository. If you checkout a tag name, you'll have exactly the same as
+  you find in the release archives::
 
-      git checkout master
-
-  And the current development version in the ``develop`` branch::
-
-      git checkout develop
+      git tag -l
+      git checkout v3.0.0
 
 
 Software requirements
@@ -39,11 +39,11 @@ It is recommended to create a `virtualenv <https://virtualenv.pypa.io/>`_ to
 isolate the dependencies from other applications on the same system::
 
     cd comics/
-    virtualenv ../comics-virtualenv/
+    virtualenv .venv/
 
 Every time you want to use the virtualenv, it must be activated::
 
-    source ../comics-virtualenv/bin/activate
+    source .venv/bin/activate
 
 The dependencies can be installed using `pip <https://pip.pypa.io/>`_::
 
@@ -78,82 +78,3 @@ There are also some additional requirements only needed for development, which
 are listed in the file ``requirements-dev.txt``:
 
 .. literalinclude:: ../requirements-dev.txt
-
-
-Run Comics
-============
-
-To get Comics to a state useful for testing of new crawlers and personal
-usage, the following steps are all that is needed.
-
-
-Create database
----------------
-
-A file-based SQLite database will be used, unless you have configured another
-database, like PostgreSQL.
-
-To create the database and database schema, open a terminal, go to top level
-directory in your checkout of the comics repo, where you'll find the file
-``manage.py``, and run::
-
-    python manage.py migrate
-
-When migrate has finished, create a superuser by running::
-
-    python manage.py createsuperuser
-
-
-Seed database
--------------
-
-Then we need to seed the database with information on what comics to crawl.
-E.g. to add the *XKCD* comic from ``comics/comics/comics/xkcd.py``, run::
-
-    python manage.py comics_addcomics -c xkcd
-
-Optionally, you can add all available active comics to the database::
-
-    python manage.py comics_addcomics -c all
-
-
-Get some comic releases
------------------------
-
-Next, we need to get hold of some comic releases, so we will crawl the web for
-them. This will get today's releases for all added comics::
-
-    python manage.py comics_getreleases
-
-To get the release for a specific added comics, you can filter with
-:option:`--comic` or :option:`-c`::
-
-    python manage.py comics_getreleases -c xkcd
-
-To get releases for a range of days, you can specify a date range with
-:option:`--from` or :option:`-f` and :option:`--to` or :option:`-t`. Both
-defaults to today, so you can leave the end of the range out::
-
-    python manage.py comics_getreleases -f 2011-11-11
-
-
-Development web server
-----------------------
-
-Finally, to be able to browse the comic releases we have aggregated, start the
-Django development web server by running::
-
-    python manage.py runserver
-
-If you now point your web browser at http://localhost:8000/ you will be able to
-browse all available comics. If you created a superuser above, you can log in
-at http://localhost:8000/admin/ to do simple administration tasks, like
-removing comics or releases.
-
-
-More options
-------------
-
-All of the ``manage.py`` commands got more options available. Add the
-:option:`--help` argument to any of the commands to get a full listing of the
-available options.

--- a/docs/webservice.rst
+++ b/docs/webservice.rst
@@ -188,24 +188,24 @@ Users resource
 
     .. sourcecode:: http
 
-        HTTP/1.0 200 OK
+        HTTP/1.1 200 OK
         Content-Type: application/json; charset=utf-8
 
         {
-            meta: {
-                limit: 20,
-                next: null,
-                offset: 0,
-                previous: null,
-                total_count: 1
+            "meta": {
+                "limit": 20,
+                "next": null,
+                "offset": 0,
+                "previous": null,
+                "total_count": 1
             },
-            objects: [
+            "objects": [
                 {
-                    date_joined: "2012-04-30T18:39:59+00:00",
-                    email: "alice@example.com",
-                    last_login: "2012-06-09T23:09:54.312109+00:00",
-                    resource_uri: "/api/v1/users/1/",
-                    secret_key: "76acdcdf16ae4e12becb00d09a9d9456"
+                    "date_joined": "2012-04-30T18:39:59+00:00",
+                    "email": "alice@example.com",
+                    "last_login": "2012-06-09T23:09:54.312109+00:00",
+                    "resource_uri": "/api/v1/users/1/",
+                    "secret_key": "76acdcdf16ae4e12becb00d09a9d9456"
                 }
             ]
         }
@@ -234,30 +234,30 @@ Comics resource
 
     .. sourcecode:: http
 
-        HTTP/1.0 200 OK
+        HTTP/1.1 200 OK
         Content-Type: application/json; charset=utf-8
 
         {
-            meta: {
-                limit: 20,
-                next: null,
-                offset: 0,
-                previous: null,
-                total_count: 1
+            "meta": {
+                "limit": 20,
+                "next": null,
+                "offset": 0,
+                "previous": null,
+                "total_count": 1
             },
-            objects: [
+            "objects": [
                 {
-                    active: true,
-                    added: "0001-01-01T00:00:00+00:00",
-                    end_date: null,
-                    id: "18",
-                    language: "en",
-                    name: "xkcd",
-                    resource_uri: "/api/v1/comics/18/",
-                    rights: "Randall Munroe, CC BY-NC 2.5",
-                    slug: "xkcd",
-                    start_date: "2005-05-29",
-                    url: "http://www.xkcd.com/"
+                    "active": true,
+                    "added": "0001-01-01T00:00:00+00:00",
+                    "end_date": null,
+                    "id": "18",
+                    "language": "en",
+                    "name": "xkcd",
+                    "resource_uri": "/api/v1/comics/18/",
+                    "rights": "Randall Munroe, CC BY-NC 2.5",
+                    "slug": "xkcd",
+                    "start_date": "2005-05-29",
+                    "url": "http://www.xkcd.com/"
                 }
             ]
         }
@@ -293,21 +293,21 @@ Comics resource
 
     .. sourcecode:: http
 
-        HTTP/1.0 200 OK
+        HTTP/1.1 200 OK
         Content-Type: application/json; charset=utf-8
 
         {
-            active: true,
-            added: "0001-01-01T00:00:00+00:00",
-            end_date: null,
-            id: "18",
-            language: "en",
-            name: "xkcd",
-            resource_uri: "/api/v1/comics/18/",
-            rights: "Randall Munroe, CC BY-NC 2.5",
-            slug: "xkcd",
-            start_date: "2005-05-29",
-            url: "http://www.xkcd.com/"
+            "active": true,
+            "added": "0001-01-01T00:00:00+00:00",
+            "end_date": null,
+            "id": "18",
+            "language": "en",
+            "name": "xkcd",
+            "resource_uri": "/api/v1/comics/18/",
+            "rights": "Randall Munroe, CC BY-NC 2.5",
+            "slug": "xkcd",
+            "start_date": "2005-05-29",
+            "url": "http://www.xkcd.com/"
         }
 
     :param comic_id: the comic ID
@@ -338,57 +338,57 @@ Releases resource
 
     .. sourcecode:: http
 
-        HTTP/1.0 200 OK
+        HTTP/1.1 200 OK
         Content-Type: application/json; charset=utf-8
 
         {
-            meta: {
-                limit: 2,
-                next: "/api/v1/releases/?limit=2&key=76acdcdf16ae4e12becb00d09a9d9456&format=json&comic__slug=xkcd&offset=2",
-                offset: 0,
-                previous: null,
-                total_count: 1104
+            "meta": {
+                "limit": 2,
+                "next": "/api/v1/releases/?limit=2&key=76acdcdf16ae4e12becb00d09a9d9456&format=json&comic__slug=xkcd&offset=2",
+                "offset": 0,
+                "previous": null,
+                "total_count": 1104
             },
-            objects: [
+            "objects": [
                 {
-                    comic: "/api/v1/comics/18/",
-                    fetched: "2012-10-08T04:03:56.411028+00:00",
-                    id: "147708",
-                    images: [
+                    "comic": "/api/v1/comics/18/",
+                    "fetched": "2012-10-08T04:03:56.411028+00:00",
+                    "id": "147708",
+                    "images": [
                         {
-                            checksum: "605d9a6d415676a21ee286fe2b369f58db62c397bfdfa18710b96dcbbcc4df12",
-                            fetched: "2012-10-08T04:03:56.406586+00:00",
-                            file: "https://static.example.com/media/xkcd/6/605d9a6d415676a21ee286fe2b369f58db62c397bfdfa18710b96dcbbcc4df12.png",
-                            height: 365,
-                            id: "151937",
-                            resource_uri: "/api/v1/images/151937/",
-                            text: "Facebook, Apple, and Google all got away with their monopolist power grabs because they don't have any 'S's in their names for critics to snarkily replace with '$'s.",
-                            title: "Microsoft",
-                            width: 278
+                            "checksum": "605d9a6d415676a21ee286fe2b369f58db62c397bfdfa18710b96dcbbcc4df12",
+                            "fetched": "2012-10-08T04:03:56.406586+00:00",
+                            "file": "https://static.example.com/media/xkcd/6/605d9a6d415676a21ee286fe2b369f58db62c397bfdfa18710b96dcbbcc4df12.png",
+                            "height": 365,
+                            "id": "151937",
+                            "resource_uri": "/api/v1/images/151937/",
+                            "text": "Facebook, Apple, and Google all got away with their monopolist power grabs because they don't have any 'S's in their names for critics to snarkily replace with '$'s.",
+                            "title": "Microsoft",
+                            "width": 278
                         }
                     ],
-                    pub_date: "2012-10-08",
-                    resource_uri: "/api/v1/releases/147708/"
+                    "pub_date": "2012-10-08",
+                    "resource_uri": "/api/v1/releases/147708/"
                 },
                 {
-                    comic: "/api/v1/comics/18/",
-                    fetched: "2012-10-05T05:03:33.744355+00:00",
-                    id: "147172",
-                    images: [
+                    "comic": "/api/v1/comics/18/",
+                    "fetched": "2012-10-05T05:03:33.744355+00:00",
+                    "id": "147172",
+                    "images": [
                         {
-                            checksum: "6d1b67d3dc00d362ddb5b5e8f1c3f174926d2998ca497e8737ff8b74e7100997",
-                            fetched: "2012-10-05T05:03:33.737231+00:00",
-                            file: "https://static.example.com/media/xkcd/6/6d1b67d3dc00d362ddb5b5e8f1c3f174926d2998ca497e8737ff8b74e7100997.png",
-                            height: 254,
-                            id: "151394",
-                            resource_uri: "/api/v1/images/151394/",
-                            text: "According to my mom, my first word was (looking up at the sky) 'Wow!'",
-                            title: "My Sky",
-                            width: 713
+                            "checksum": "6d1b67d3dc00d362ddb5b5e8f1c3f174926d2998ca497e8737ff8b74e7100997",
+                            "fetched": "2012-10-05T05:03:33.737231+00:00",
+                            "file": "https://static.example.com/media/xkcd/6/6d1b67d3dc00d362ddb5b5e8f1c3f174926d2998ca497e8737ff8b74e7100997.png",
+                            "height": 254,
+                            "id": "151394",
+                            "resource_uri": "/api/v1/images/151394/",
+                            "text": "According to my mom, my first word was (looking up at the sky) 'Wow!'",
+                            "title": "My Sky",
+                            "width": 713
                         }
                     ],
-                    pub_date: "2012-10-05",
-                    resource_uri: "/api/v1/releases/147172/"
+                    "pub_date": "2012-10-05",
+                    "resource_uri": "/api/v1/releases/147172/"
                 }
             ]
         }
@@ -426,28 +426,28 @@ Releases resource
 
     .. sourcecode:: http
 
-        HTTP/1.0 200 OK
+        HTTP/1.1 200 OK
         Content-Type: application/json; charset=utf-8
 
         {
-            comic: "/api/v1/comics/18/",
-            fetched: "2012-10-08T04:03:56.411028+00:00",
-            id: "147708",
-            images: [
+            "comic": "/api/v1/comics/18/",
+            "fetched": "2012-10-08T04:03:56.411028+00:00",
+            "id": "147708",
+            "images": [
                 {
-                    checksum: "605d9a6d415676a21ee286fe2b369f58db62c397bfdfa18710b96dcbbcc4df12",
-                    fetched: "2012-10-08T04:03:56.406586+00:00",
-                    file: "https://static.example.com/media/xkcd/6/605d9a6d415676a21ee286fe2b369f58db62c397bfdfa18710b96dcbbcc4df12.png",
-                    height: 365,
-                    id: "151937",
-                    resource_uri: "/api/v1/images/151937/",
-                    text: "Facebook, Apple, and Google all got away with their monopolist power grabs because they don't have any 'S's in their names for critics to snarkily replace with '$'s.",
-                    title: "Microsoft",
-                    width: 278
+                    "checksum": "605d9a6d415676a21ee286fe2b369f58db62c397bfdfa18710b96dcbbcc4df12",
+                    "fetched": "2012-10-08T04:03:56.406586+00:00",
+                    "file": "https://static.example.com/media/xkcd/6/605d9a6d415676a21ee286fe2b369f58db62c397bfdfa18710b96dcbbcc4df12.png",
+                    "height": 365,
+                    "id": "151937",
+                    "resource_uri": "/api/v1/images/151937/",
+                    "text": "Facebook, Apple, and Google all got away with their monopolist power grabs because they don't have any 'S's in their names for critics to snarkily replace with '$'s.",
+                    "title": "Microsoft",
+                    "width": 278
                 }
             ],
-            pub_date: "2012-10-08",
-            resource_uri: "/api/v1/releases/147708/"
+            "pub_date": "2012-10-08",
+            "resource_uri": "/api/v1/releases/147708/"
         }
 
     :param release_id: the release ID
@@ -516,22 +516,22 @@ Subscriptions resource
 
     .. sourcecode:: http
 
-        HTTP/1.0 200 OK
+        HTTP/1.1 200 OK
         Content-Type: application/json; charset=utf-8
 
         {
-            meta: {
-                limit: 20,
-                next: null,
-                offset: 0,
-                previous: null,
-                total_count: 1
+            "meta": {
+                "limit": 20,
+                "next": null,
+                "offset": 0,
+                "previous": null,
+                "total_count": 1
             },
-            objects: [
+            "objects": [
                 {
-                    comic: "/api/v1/comics/18/",
-                    id: "2",
-                    resource_uri: "/api/v1/subscriptions/2/"
+                    "comic": "/api/v1/comics/18/",
+                    "id": "2",
+                    "resource_uri": "/api/v1/subscriptions/2/"
                 }
             ]
         }
@@ -567,7 +567,7 @@ Subscriptions resource
 
     .. sourcecode:: http
 
-        HTTP/1.0 201 CREATED
+        HTTP/1.1 201 CREATED
         Content-Type: text/html; charset=utf-8
         Location: https://example.com/api/v1/subscriptions/4/
 
@@ -612,7 +612,7 @@ Subscriptions resource
 
     .. sourcecode:: http
 
-        HTTP/1.0 202 ACCEPTED
+        HTTP/1.1 202 ACCEPTED
         Content-Length: 0
         Content-Type: text/html; charset=utf-8
 
@@ -640,13 +640,13 @@ Subscriptions resource
 
     .. sourcecode:: http
 
-        HTTP/1.0 200 OK
+        HTTP/1.1 200 OK
         Content-Type: application/json; charset=utf-8
 
         {
-            comic: "/api/v1/comics/18/",
-            id: "2",
-            resource_uri: "/api/v1/subscriptions/2/"
+            "comic": "/api/v1/comics/18/",
+            "id": "2",
+            "resource_uri": "/api/v1/subscriptions/2/"
         }
 
     :param subscription_id: the subscription ID
@@ -672,7 +672,7 @@ Subscriptions resource
 
     .. sourcecode:: http
 
-        HTTP/1.0 204 NO CONTENT
+        HTTP/1.1 204 NO CONTENT
         Content-Length: 0
         Content-Type: text/html; charset=utf-8
 

--- a/docs/webservice.rst
+++ b/docs/webservice.rst
@@ -2,15 +2,15 @@
 Web service
 ***********
 
-*comics* comes with a web service that exposes all useful data about the
+Comics comes with a web service that exposes all useful data about the
 current user, the user's comics subscriptions, comics, comic releases, and
 comic images. The web service may be used to e.g. create iOS/Android apps or
 alternative comics browsers, while leaving the comics crawling job to a
-*comics* instance.
+Comics instance.
 
 Please make any apps using this API generic, so that they can be used with any
-*comics* instance as the backend. In other words, when starting your app, let
-the end user enter the hostname of the *comics* instance, in addition to his
+Comics instance as the backend. In other words, when starting your app, let
+the end user enter the hostname of the Comics instance, in addition to his
 secret key or email/password pair.
 
 
@@ -18,9 +18,9 @@ Authentication
 ==============
 
 The web service is only available for users with an active user account on the
-*comics* instance. The user must authenticate himself using the same
+Comics instance. The user must authenticate himself using the same
 secret key as is used to access comic feeds. The key can be found in the
-account section of the *comics* instance.
+account section of the Comics instance.
 
 The secret key can be provided in one of two ways:
 
@@ -37,17 +37,17 @@ Get secret key using email and password
 ---------------------------------------
 
 If it's inconvenient for the end user to enter the secret key in your user
-interface--on mobile phones copy-pasting the API key from the *comics*
+interface--on mobile phones copy-pasting the API key from the Comics
 instance's account page is time consuming at best--you may retrieve the secret
 key on behalf of the end user by following steps:
 
 1. Ask the end user to provide:
 
-   - the *comics* instance's base URL (e.g. ``example.com``)
+   - the Comics instance's base URL (e.g. ``example.com``)
 
-   - the email address the end user have registered on the *comics* instance
+   - the email address the end user have registered on the Comics instance
 
-   - the password the end user have registered on the *comics* instance
+   - the password the end user have registered on the Comics instance
 
 2. Use the provided information to retrieve the :ref:`users-resource` from the
    API. Authenticate using `Basic Authentication
@@ -108,10 +108,10 @@ You can specify what response format you prefer in one of two ways:
       Accept: application/x-plist
 
 JSON and JSONP are always supported. Other formats like XML, YAML, and Apple
-binary plists (bplist) may be available if the *comics* instance got the
+binary plists (bplist) may be available if the Comics instance got the
 additional dependencies required by the format installed.
 
-If you run a *comics* instance yourself, and want support for more response
+If you run a Comics instance yourself, and want support for more response
 formats, check out `Tastypie's serialization docs
 <https://django-tastypie.readthedocs.io/en/latest/serialization.html>`_ for
 details on what you need to install.


### PR DESCRIPTION
- Capitalize 'Comics' instead of italizing it
- Split ToC into three sections
- Split installation and bootstrapping
- Update deployment docs
- Tweak crawler docs
- Fix formatting of HTTP examples
- Fix warnings
