### PR TITLE
Upgrade to Django 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,11 @@ Comics runs on Python and Django. For instructions on how to install and use it,
 ## Development status
 
 The Comics project is almost as old as Django itself, with the code base
-originating back to 2007. Currently, it is a bit stagnated, still running on
-Django 2.2.
-
-However, as of 2021, the project isn't entirely dead: the project maintainer
-is still running his own instance with a number of regular users. There are
-no immediate plans for any new features, but there is a
-[roadmap](https://github.com/jodal/comics/projects/1) for getting Comics
-up and running on the latest dependency releases, with a modern and
+originating back to 2007. However, as of 2021, the project isn't entirely
+dead: the project maintainer is still running his own instance with a number
+of regular users. There are no immediate plans for any new features, but
+there is a [roadmap](https://github.com/jodal/comics/projects/1) for getting
+Comics up and running on the latest dependency releases, with a modern and
 maintainable deployment setup.
 
 ## License

--- a/comics/__init__.py
+++ b/comics/__init__.py
@@ -1,5 +1,21 @@
 import logging
+import warnings
+
+from django.utils.deprecation import RemovedInDjango40Warning
 
 # Install a default log handler so that we don't get errors about missing log
 # handlers when running tests.
 logging.getLogger("comics").addHandler(logging.NullHandler())
+
+# Filter warnings from dependencies with known deprecation warnings to that we
+# can spot any warnings from our own code.
+warnings.filterwarnings(
+    action="ignore",
+    category=RemovedInDjango40Warning,
+    module="invitations",
+)
+warnings.filterwarnings(
+    action="ignore",
+    category=RemovedInDjango40Warning,
+    module="tastypie",
+)

--- a/comics/accounts/models.py
+++ b/comics/accounts/models.py
@@ -19,7 +19,9 @@ def make_secret_key():
 
 class UserProfile(models.Model):
     user = models.OneToOneField(
-        User, on_delete=models.CASCADE, related_name="comics_profile"
+        User,
+        on_delete=models.CASCADE,
+        related_name="comics_profile",
     )
     secret_key = models.CharField(
         max_length=32,
@@ -27,7 +29,10 @@ class UserProfile(models.Model):
         default=make_secret_key,
         help_text="Secret key for feed and API access",
     )
-    comics = models.ManyToManyField(Comic, through="Subscription")
+    comics = models.ManyToManyField(
+        Comic,
+        through="Subscription",
+    )
 
     class Meta:
         db_table = "comics_user_profile"

--- a/comics/core/enums.py
+++ b/comics/core/enums.py
@@ -1,0 +1,6 @@
+from django.db.models import TextChoices
+
+
+class Language(TextChoices):
+    EN = "en", "English"
+    NO = "no", "Norwegian"

--- a/comics/core/models.py
+++ b/comics/core/models.py
@@ -7,15 +7,11 @@ from django.db import models
 from django.urls import reverse
 from django.utils import timezone
 
+from comics.core.enums import Language
 from comics.core.managers import ComicManager
 
 
 class Comic(models.Model):
-    LANGUAGES = (
-        ("en", "English"),
-        ("no", "Norwegian"),
-    )
-
     # Required fields
     name = models.CharField(max_length=100, help_text="Name of the comic")
     slug = models.SlugField(
@@ -25,7 +21,7 @@ class Comic(models.Model):
         help_text="For file paths and URLs",
     )
     language = models.CharField(
-        max_length=2, choices=LANGUAGES, help_text="The language of the comic"
+        max_length=2, choices=Language.choices, help_text="The language of the comic"
     )
 
     # Optional fields

--- a/comics/core/models.py
+++ b/comics/core/models.py
@@ -13,7 +13,10 @@ from comics.core.managers import ComicManager
 
 class Comic(models.Model):
     # Required fields
-    name = models.CharField(max_length=100, help_text="Name of the comic")
+    name = models.CharField(
+        max_length=100,
+        help_text="Name of the comic",
+    )
     slug = models.SlugField(
         max_length=100,
         unique=True,
@@ -21,17 +24,26 @@ class Comic(models.Model):
         help_text="For file paths and URLs",
     )
     language = models.CharField(
-        max_length=2, choices=Language.choices, help_text="The language of the comic"
+        max_length=2,
+        choices=Language.choices,
+        help_text="The language of the comic",
     )
 
     # Optional fields
     url = models.URLField(
-        verbose_name="URL", blank=True, help_text="URL to the official website"
+        verbose_name="URL",
+        blank=True,
+        help_text="URL to the official website",
     )
     active = models.BooleanField(
-        default=True, help_text="Wheter the comic is still being crawled"
+        default=True,
+        help_text="Wheter the comic is still being crawled",
     )
-    start_date = models.DateField(blank=True, null=True, help_text="First published at")
+    start_date = models.DateField(
+        blank=True,
+        null=True,
+        help_text="First published at",
+    )
     end_date = models.DateField(
         blank=True,
         null=True,
@@ -45,7 +57,8 @@ class Comic(models.Model):
 
     # Automatically populated fields
     added = models.DateTimeField(
-        auto_now_add=True, help_text="Time the comic was added to the site"
+        auto_now_add=True,
+        help_text="Time the comic was added to the site",
     )
 
     objects = ComicManager()
@@ -72,9 +85,18 @@ class Comic(models.Model):
 
 class Release(models.Model):
     # Required fields
-    comic = models.ForeignKey(Comic, on_delete=models.CASCADE)
-    pub_date = models.DateField(verbose_name="publication date", db_index=True)
-    images = models.ManyToManyField("Image", related_name="releases")
+    comic = models.ForeignKey(
+        Comic,
+        on_delete=models.CASCADE,
+    )
+    pub_date = models.DateField(
+        verbose_name="publication date",
+        db_index=True,
+    )
+    images = models.ManyToManyField(
+        "Image",
+        related_name="releases",
+    )
 
     # Automatically populated fields
     fetched = models.DateTimeField(auto_now_add=True, db_index=True)
@@ -118,21 +140,34 @@ def image_file_path(instance, filename):
 
 class Image(models.Model):
     # Required fields
-    comic = models.ForeignKey(Comic, on_delete=models.CASCADE)
+    comic = models.ForeignKey(
+        Comic,
+        on_delete=models.CASCADE,
+    )
     file = models.ImageField(
         storage=image_storage,
         upload_to=image_file_path,
         height_field="height",
         width_field="width",
     )
-    checksum = models.CharField(max_length=64, db_index=True)
+    checksum = models.CharField(
+        max_length=64,
+        db_index=True,
+    )
 
     # Optional fields
-    title = models.CharField(max_length=255, blank=True)
-    text = models.TextField(blank=True)
+    title = models.CharField(
+        max_length=255,
+        blank=True,
+    )
+    text = models.TextField(
+        blank=True,
+    )
 
     # Automatically populated fields
-    fetched = models.DateTimeField(auto_now_add=True)
+    fetched = models.DateTimeField(
+        auto_now_add=True,
+    )
     height = models.IntegerField()
     width = models.IntegerField()
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "asgiref"
+version = "3.3.1"
+description = "ASGI specs, helper code, and adapters"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+tests = ["pytest", "pytest-asyncio"]
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -165,13 +176,14 @@ python-versions = "*"
 
 [[package]]
 name = "django"
-version = "2.2.19"
+version = "3.1.7"
 description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
+asgiref = ">=3.2.10,<4"
 pytz = "*"
 sqlparse = ">=0.2.2"
 
@@ -1006,13 +1018,17 @@ server = ["gunicorn"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "3.7"
-content-hash = "c17ce1dd192e76cfe9229c4576e969946454dedc4ffd6f05cded06216deab06c"
+python-versions = "^3.7"
+content-hash = "4377b63a7e86193f6b2f6dfb10947f91df7661c9d932b13d6963172855725afc"
 
 [metadata.files]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+asgiref = [
+    {file = "asgiref-3.3.1-py3-none-any.whl", hash = "sha256:5ee950735509d04eb673bd7f7120f8fa1c9e2df495394992c73234d526907e17"},
+    {file = "asgiref-3.3.1.tar.gz", hash = "sha256:7162a3cb30ab0609f1a4c95938fd73e8604f63bdba516a7f7d64b83ff09478f0"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -1168,8 +1184,8 @@ distlib = [
     {file = "distlib-0.3.1.zip", hash = "sha256:edf6116872c863e1aa9d5bb7cb5e05a022c519a4594dc703843343a9ddd9bff1"},
 ]
 django = [
-    {file = "Django-2.2.19-py3-none-any.whl", hash = "sha256:e319a7164d6d30cb177b3fd74d02c52f1185c37304057bb76d74047889c605d9"},
-    {file = "Django-2.2.19.tar.gz", hash = "sha256:30c235dec87e05667597e339f194c9fed6c855bda637266ceee891bf9093da43"},
+    {file = "Django-3.1.7-py3-none-any.whl", hash = "sha256:baf099db36ad31f970775d0be5587cc58a6256a6771a44eb795b554d45f211b8"},
+    {file = "Django-3.1.7.tar.gz", hash = "sha256:32ce792ee9b6a0cbbec340123e229ac9f765dff8c2a4ae9247a14b2ba3a365a7"},
 ]
 django-allauth = [
     {file = "django-allauth-0.44.0.tar.gz", hash = "sha256:e51af457466022f52154d74c8523ac69375120fad2acce6e239635d85e610b25"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -244,14 +244,14 @@ six = ">=1.12.0"
 
 [[package]]
 name = "django-debug-toolbar"
-version = "2.2"
+version = "3.2"
 description = "A configurable set of panels that display various debug information about the current request/response."
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
-Django = ">=1.11"
+Django = ">=2.2"
 sqlparse = ">=0.2.0"
 
 [[package]]
@@ -1019,7 +1019,7 @@ server = ["gunicorn"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "4377b63a7e86193f6b2f6dfb10947f91df7661c9d932b13d6963172855725afc"
+content-hash = "bf74c305ecf05dc1f570f78edd1af9d79ec7b7754a31c81ecfe7d9e68f06d943"
 
 [metadata.files]
 appdirs = [
@@ -1202,8 +1202,8 @@ django-compressor = [
     {file = "django_compressor-2.4.tar.gz", hash = "sha256:d2ed1c6137ddaac5536233ec0a819e14009553fee0a869bea65d03e5285ba74f"},
 ]
 django-debug-toolbar = [
-    {file = "django-debug-toolbar-2.2.tar.gz", hash = "sha256:eabbefe89881bbe4ca7c980ff102e3c35c8e8ad6eb725041f538988f2f39a943"},
-    {file = "django_debug_toolbar-2.2-py3-none-any.whl", hash = "sha256:ff94725e7aae74b133d0599b9bf89bd4eb8f5d2c964106e61d11750228c8774c"},
+    {file = "django-debug-toolbar-3.2.tar.gz", hash = "sha256:84e2607d900dbd571df0a2acf380b47c088efb787dce9805aefeb407341961d2"},
+    {file = "django_debug_toolbar-3.2-py3-none-any.whl", hash = "sha256:9e5a25d0c965f7e686f6a8ba23613ca9ca30184daa26487706d4829f5cfb697a"},
 ]
 django-environ = [
     {file = "django-environ-0.4.5.tar.gz", hash = "sha256:6c9d87660142608f63ec7d5ce5564c49b603ea8ff25da595fd6098f6dc82afde"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -264,14 +264,11 @@ python-versions = "*"
 
 [[package]]
 name = "django-extensions"
-version = "2.2.9"
+version = "3.1.1"
 description = "Extensions for Django"
 category = "dev"
 optional = false
-python-versions = "*"
-
-[package.dependencies]
-six = ">=1.2"
+python-versions = ">=3.6"
 
 [[package]]
 name = "django-invitations"
@@ -1019,7 +1016,7 @@ server = ["gunicorn"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "bf74c305ecf05dc1f570f78edd1af9d79ec7b7754a31c81ecfe7d9e68f06d943"
+content-hash = "e83286a0b78b725ab53e906d01cbd17b7c5deda1d6c579c940c2532b6cfc1d66"
 
 [metadata.files]
 appdirs = [
@@ -1210,8 +1207,8 @@ django-environ = [
     {file = "django_environ-0.4.5-py2.py3-none-any.whl", hash = "sha256:c57b3c11ec1f319d9474e3e5a79134f40174b17c7cc024bbb2fad84646b120c4"},
 ]
 django-extensions = [
-    {file = "django-extensions-2.2.9.tar.gz", hash = "sha256:2f81b618ba4d1b0e58603e25012e5c74f88a4b706e0022a3b21f24f0322a6ce6"},
-    {file = "django_extensions-2.2.9-py2.py3-none-any.whl", hash = "sha256:b19182d101a441fe001c5753553a901e2ef3ff60e8fbbe38881eb4a61fdd17c4"},
+    {file = "django-extensions-3.1.1.tar.gz", hash = "sha256:674ad4c3b1587a884881824f40212d51829e662e52f85b012cd83d83fe1271d9"},
+    {file = "django_extensions-3.1.1-py3-none-any.whl", hash = "sha256:9507f8761ee760748938fd8af766d0608fb2738cf368adfa1b2451f61c15ae35"},
 ]
 django-invitations = [
     {file = "django-invitations-1.9.3.tar.gz", hash = "sha256:6077807aa641c7abae9ca418e757c8e3940fb0ce60499dba24c100ad57c61442"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ sentry-sdk = "^1.0.0"
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"
 django-debug-toolbar = "^3.2"
-django-extensions = "<3"
+django-extensions = "^3.1.1"
 flake8 = "^3.9.0"
 flake8-black = "^0.2.1"
 flake8-bugbear = "^21.3.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,10 @@ target-version = ["py37"]
 profile = "black"
 
 [tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::django.utils.deprecation.RemovedInDjango40Warning:invitations",
+    "ignore::django.utils.deprecation.RemovedInDjango40Warning:tastypie",
+]
 DJANGO_SETTINGS_MODULE = "comics.settings"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ sentry-sdk = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"
-django-debug-toolbar = "<3"
+django-debug-toolbar = "^3.2"
 django-extensions = "<3"
 flake8 = "^3.9.0"
 flake8-black = "^0.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ biplist = {version = "^1.0.3", optional = true}
 cssmin = "^0.2.0"
 cssselect = "^1.1.0"
 defusedxml = "^0.7.1"
-django = "^2.2.19"
+Django = "^3.1.7"
 django-allauth = "^0.44.0"
 django-bootstrap-form = "^3.4"
 django-compressor = "^2.4"


### PR DESCRIPTION
- Upgrade Django from 2.2 to 3.1
- Upgrade django-debug-toolbar from 2.2 to 3.2
- Upgrade django-extensions from 2.2.9 to 3.1.1
- Ignore warnings in invitations and tastypie
- Use an enum for the language choices
- Reformat model fields
