### PR TITLE
Replace __unicode__ with __str__

### DIFF
--- a/comics/accounts/models.py
+++ b/comics/accounts/models.py
@@ -38,7 +38,7 @@ class UserProfile(models.Model):
         db_table = "comics_user_profile"
         verbose_name = "comics profile"
 
-    def __unicode__(self):
+    def __str__(self):
         return "Comics profile for %s" % self.user.email
 
     def generate_new_secret_key(self):
@@ -52,7 +52,7 @@ class Subscription(models.Model):
     class Meta:
         db_table = "comics_user_profile_comics"
 
-    def __unicode__(self):
+    def __str__(self):
         return "Subscription for {} to {}".format(
             self.userprofile.user.email,
             self.comic.slug,

--- a/comics/core/admin.py
+++ b/comics/core/admin.py
@@ -42,7 +42,7 @@ class ComicAdmin(admin.ModelAdmin):
 
 @admin.register(models.Release)
 class ReleaseAdmin(admin.ModelAdmin):
-    list_display = ("__unicode__", "comic", "pub_date", "fetched")
+    list_display = ("__str__", "comic", "pub_date", "fetched")
     list_filter = ["pub_date", "fetched", "comic"]
     date_hierarchy = "pub_date"
     exclude = ("images",)
@@ -64,7 +64,7 @@ def text_preview(obj):
 @admin.register(models.Image)
 class ImageAdmin(admin.ModelAdmin):
     list_display = (
-        "__unicode__",
+        "__str__",
         "file",
         "height",
         "width",

--- a/comics/core/models.py
+++ b/comics/core/models.py
@@ -67,7 +67,7 @@ class Comic(models.Model):
         db_table = "comics_comic"
         ordering = ["name"]
 
-    def __unicode__(self):
+    def __str__(self):
         return self.slug
 
     def get_absolute_url(self):
@@ -106,7 +106,7 @@ class Release(models.Model):
         indexes = [models.Index(fields=["comic", "pub_date"])]
         get_latest_by = "pub_date"
 
-    def __unicode__(self):
+    def __str__(self):
         return f"Release {self.comic.slug}/{self.pub_date}"
 
     def get_absolute_url(self):
@@ -174,5 +174,5 @@ class Image(models.Model):
     class Meta:
         db_table = "comics_image"
 
-    def __unicode__(self):
+    def __str__(self):
         return "Image {}/{}...".format(self.comic.slug, self.checksum[:8])


### PR DESCRIPTION
In Python 3 __unicode__ method has no effect and should be replaced with __str__
https://docs.djangoproject.com/en/1.11/topics/python3/#str-and-unicode-methods