### PR TITLE
Crawlers/site changes

### DIFF
--- a/comics/comics/babyblues.py
+++ b/comics/comics/babyblues.py
@@ -1,16 +1,16 @@
-from comics.aggregator.crawler import ComicsKingdomCrawlerBase
+from comics.aggregator.crawler import GoComicsComCrawlerBase
 from comics.core.comic_data import ComicDataBase
 
 
 class ComicData(ComicDataBase):
     name = "Baby Blues"
     language = "en"
-    url = "https://www.comicskingdom.com/babyblues"
+    url = "https://www.gocomics.com/babyblues"
     start_date = "1990-01-01"
     rights = "Rick Kirkman and Jerry Scott"
 
 
-class Crawler(ComicsKingdomCrawlerBase):
+class Crawler(GoComicsComCrawlerBase):
     history_capable_date = "2011-11-26"
     schedule = "Mo,Tu,We,Th,Fr,Sa,Su"
     time_zone = "US/Eastern"

--- a/comics/comics/hjalmarbt.py
+++ b/comics/comics/hjalmarbt.py
@@ -1,0 +1,20 @@
+from comics.aggregator.crawler import CrawlerBase, CrawlerImage
+from comics.core.comic_data import ComicDataBase
+
+
+class ComicData(ComicDataBase):
+    name = "Hjalmar (bt.no)"
+    language = "no"
+    url = "https://www.bt.no/kultur/tegneserier/"
+    rights = "Nils Axle Kanten"
+
+
+class Crawler(CrawlerBase):
+    history_capable_date = "2013-01-15"
+    schedule = "Mo,Tu,We,Th,Fr,Sa,Su"
+
+    def crawl(self, pub_date):
+        url = "https://cartoon-prod.schibsted.tech/rocky/%s.gif" % (
+            pub_date.strftime("%d%m%y"),
+        )
+        return CrawlerImage(url)

--- a/comics/comics/nemibt.py
+++ b/comics/comics/nemibt.py
@@ -1,4 +1,4 @@
-from comics.aggregator.crawler import CrawlerBase
+from comics.aggregator.crawler import CrawlerBase, CrawlerImage
 from comics.core.comic_data import ComicDataBase
 
 
@@ -8,11 +8,15 @@ class ComicData(ComicDataBase):
     url = "https://www.bt.no/kultur/tegneserier/"
     start_date = "1997-01-01"
     rights = "Lise Myhre"
-    active = False
 
 
 class Crawler(CrawlerBase):
+    history_capable_date = "2008-07-01"
+    schedule = "Mo,Tu,We,Th,Fr,Sa"
     time_zone = "Europe/Oslo"
 
     def crawl(self, pub_date):
-        pass
+        url = "https://cartoon-prod.schibsted.tech/nemi/{}.gif".format(
+            pub_date.strftime("%d%m%y"),
+        )
+        return CrawlerImage(url)

--- a/comics/comics/pondusbt.py
+++ b/comics/comics/pondusbt.py
@@ -1,15 +1,20 @@
-from comics.aggregator.crawler import CrawlerBase
+from comics.aggregator.crawler import CrawlerBase, CrawlerImage
 from comics.comics.pondus import ComicData as PondusData
 
 
 class ComicData(PondusData):
     name = "Pondus (bt.no)"
     url = "https://www.bt.no/kultur/tegneserier/"
-    active = False
+    active = True
 
 
 class Crawler(CrawlerBase):
+    history_capable_date = "2008-07-01"
+    schedule = "Mo,Tu,We,Th,Fr,Sa,Su"
     time_zone = "Europe/Oslo"
 
     def crawl(self, pub_date):
-        pass
+        url = "https://cartoon-prod.schibsted.tech/pondus/{}.gif".format(
+            pub_date.strftime("%d%m%y"),
+        )
+        return CrawlerImage(url)

--- a/comics/comics/sinfest.py
+++ b/comics/comics/sinfest.py
@@ -1,11 +1,12 @@
 from comics.aggregator.crawler import CrawlerBase, CrawlerImage
+from comics.aggregator.exceptions import CrawlerError
 from comics.core.comic_data import ComicDataBase
 
 
 class ComicData(ComicDataBase):
     name = "Sinfest"
     language = "en"
-    url = "http://www.sinfest.net/"
+    url = "https://sinfest.xyz/"
     start_date = "2001-01-17"
     rights = "Tatsuya Ishida"
 
@@ -16,7 +17,13 @@ class Crawler(CrawlerBase):
     time_zone = "US/Eastern"
 
     def crawl(self, pub_date):
-        url = "http://www.sinfest.net/btphp/comics/{}.gif".format(
-            pub_date.strftime("%Y-%m-%d"),
-        )
-        return CrawlerImage(url)
+        try:
+            url = "https://sinfest.xyz/btphp/comics/{}.jpg".format(
+                pub_date.strftime("%Y-%m-%d"),
+            )
+            return CrawlerImage(url)
+        except CrawlerError:  # Some releases use gif
+            url = "https://sinfest.xyz/btphp/comics/{}.gif".format(
+                pub_date.strftime("%Y-%m-%d"),
+            )
+            return CrawlerImage(url)

--- a/comics/comics/slagoon.py
+++ b/comics/comics/slagoon.py
@@ -1,4 +1,4 @@
-from comics.aggregator.crawler import CrawlerBase, CrawlerImage
+from comics.aggregator.crawler import GoComicsComCrawlerBase
 from comics.core.comic_data import ComicDataBase
 
 
@@ -10,17 +10,10 @@ class ComicData(ComicDataBase):
     rights = "Jim Toomey"
 
 
-class Crawler(CrawlerBase):
+class Crawler(GoComicsComCrawlerBase):
     history_capable_date = "2003-12-29"
     schedule = "Mo,Tu,We,Th,Fr,Sa,Su"
     time_zone = "US/Eastern"
 
     def crawl(self, pub_date):
-        page_url = "http://shermanslagoon.com/comics/{}-{}-{}/".format(
-            pub_date.strftime("%B").lower(),
-            int(pub_date.strftime("%d")),
-            pub_date.strftime("%Y"),
-        )
-        page = self.parse_page(page_url)
-        url = page.src(".entry-content img")
-        return CrawlerImage(url)
+        return self.crawl_helper("shermanslagoon", pub_date)


### PR DESCRIPTION
I previously removed the crawlers for bt.no because the page was empty/paywalled, but I discovered that the image URLs still work, so I re-added the crawlers. I also added a new crawler for "Hjalmar", it has "rocky" in the URL, but the images have been "Hjalmar" since 2018.

I also did some other fixes:
"Baby Blues" and "Sherman's Lagoon" has moved to gocomics.com
"Sinfest" use jpg images on new releases, but gif on old ones, so I added a try/except block to handle it.