### PR TITLE
refactor: Use f-strings instead of printf-style string formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,7 +189,6 @@ ignore = [
     "TD",      # flake8-todos
     "TRY",     # tryceratops  # TODO
     "TRY003",  # raise-vanilla-args
-    "UP031",   # printf-string-formatting  # TODO
     #
     # These rules interfere with `ruff format`
     "COM812", # missing-trailing-comma

--- a/src/comics/accounts/models.py
+++ b/src/comics/accounts/models.py
@@ -49,7 +49,7 @@ class UserProfile(models.Model):
         verbose_name = "comics profile"
 
     def __str__(self) -> str:
-        return "Comics profile for %s" % self.user.email
+        return f"Comics profile for {self.user.email}"
 
     def generate_new_secret_key(self) -> None:
         self.secret_key = make_secret_key()

--- a/src/comics/accounts/views.py
+++ b/src/comics/accounts/views.py
@@ -53,14 +53,14 @@ def mycomics_toggle_comic(request):
         )
         subscription.save()
         if not _is_js_request(request):
-            messages.info(request, 'Added "%s" to my comics' % comic.name)
+            messages.info(request, f'Added "{comic.name}" to my comics')
     elif "remove_comic" in request.POST:
         subscriptions = Subscription.objects.filter(
             userprofile=request.user.comics_profile, comic=comic
         )
         subscriptions.delete()
         if not _is_js_request(request):
-            messages.info(request, 'Removed "%s" from my comics' % comic.name)
+            messages.info(request, f'Removed "{comic.name}" from my comics')
 
     if _is_js_request(request):
         return HttpResponse(status=204)
@@ -86,7 +86,7 @@ def mycomics_edit_comics(request):
             )
             subscriptions.delete()
             if not _is_js_request(request):
-                messages.info(request, 'Removed "%s" from my comics' % comic.name)
+                messages.info(request, f'Removed "{comic.name}" from my comics')
 
     for comic in Comic.objects.all():
         if comic.slug in request.POST and comic not in my_comics:
@@ -95,7 +95,7 @@ def mycomics_edit_comics(request):
             )
             subscription.save()
             if not _is_js_request(request):
-                messages.info(request, 'Added "%s" to my comics' % comic.name)
+                messages.info(request, f'Added "{comic.name}" to my comics')
 
     if _is_js_request(request):
         return HttpResponse(status=204)
@@ -114,7 +114,7 @@ def invite(request):
         )
         invitation.send_invitation(request)
         messages.success(
-            request, 'An invitation has been sent to "%s".' % invitation.email
+            request, f'An invitation has been sent to "{invitation.email}".'
         )
 
     invitations = request.user.invitation_set.all().order_by("-created")

--- a/src/comics/aggregator/command.py
+++ b/src/comics/aggregator/command.py
@@ -177,7 +177,7 @@ class AggregatorConfig:
         try:
             comic = Comic.objects.get(slug=comic_slug)
         except Comic.DoesNotExist as exc:
-            error_msg = "Comic %s not found" % comic_slug
+            error_msg = f"Comic {comic_slug} not found"
             logger.error(error_msg)
             raise ComicsError(error_msg) from exc
         return comic

--- a/src/comics/aggregator/crawler.py
+++ b/src/comics/aggregator/crawler.py
@@ -249,7 +249,7 @@ class PondusNoCrawlerBase(CrawlerBase):
         url_id: str,
         pub_date: dt.date,
     ) -> CrawlerResult | None:
-        page_url = "http://www.pondus.no/?section=artikkel&id=%s" % url_id
+        page_url = f"http://www.pondus.no/?section=artikkel&id={url_id}"
         page = self.parse_page(page_url)
         url = page.src(".imagegallery img")
         assert url
@@ -268,8 +268,8 @@ class CreatorsCrawlerBase(CrawlerBase):
     ) -> CrawlerResult | None:
         api_url = (
             "https://www.creators.com/api/features/get_release_dates?"
-            "feature_id=%s&year=%s"
-        ) % (feature_id, pub_date.year)
+            f"feature_id={feature_id}&year={pub_date.year}"
+        )
 
         response = httpx.get(api_url, headers=self.headers, follow_redirects=True)
         releases = response.json()
@@ -320,9 +320,9 @@ class ComicControlCrawlerBase(CrawlerBase):
         if site_url[-1] == "/":
             site_url = site_url[0:-1]
         if "pixietrixcomix.com" in site_url:
-            feed = self.parse_feed("%s/rss" % site_url)
+            feed = self.parse_feed(f"{site_url}/rss")
         else:
-            feed = self.parse_feed("%s/comic/rss" % site_url)
+            feed = self.parse_feed(f"{site_url}/comic/rss")
 
         for entry in feed.for_date(pub_date):
             page = self.parse_page(entry.link)

--- a/src/comics/aggregator/exceptions.py
+++ b/src/comics/aggregator/exceptions.py
@@ -9,7 +9,7 @@ class AggregatorError(ComicsError):
         self.value = value
 
     def __str__(self):
-        return "%s: Generic aggregator error" % self.identifier
+        return f"{self.identifier}: Generic aggregator error"
 
 
 ###
@@ -33,7 +33,7 @@ class ImageURLNotFound(CrawlerError):
     """Exception raised when no URL is found by the crawler"""
 
     def __str__(self):
-        return "%s: Image URL not found" % self.identifier
+        return f"{self.identifier}: Image URL not found"
 
 
 class NotHistoryCapable(CrawlerError):
@@ -47,7 +47,7 @@ class ReleaseAlreadyExists(CrawlerError):
     """Exception raised when crawling a release that already exists"""
 
     def __str__(self):
-        return "%s: Release already exists" % self.identifier
+        return f"{self.identifier}: Release already exists"
 
 
 ###
@@ -85,11 +85,11 @@ class ImageAlreadyExists(DownloaderError):
     """Exception raised when trying to save an image that already exists"""
 
     def __str__(self):
-        return "%s: Image already exists" % self.identifier
+        return f"{self.identifier}: Image already exists"
 
 
 class ImageIsBlacklisted(DownloaderError):
     """Exception raised when a blacklisted image has been downloaded"""
 
     def __str__(self):
-        return "%s: Image is blacklisted" % self.identifier
+        return f"{self.identifier}: Image is blacklisted"

--- a/src/comics/aggregator/lxmlparser.py
+++ b/src/comics/aggregator/lxmlparser.py
@@ -183,9 +183,8 @@ class LxmlParser:
             case [element]:
                 return element
             case elements:
-                raise MultipleElementsReturned(
-                    "Selector matched %d elements: %s" % (len(elements), selector)
-                )
+                msg = f"Selector matched {len(elements)} elements: {selector}"
+                raise MultipleElementsReturned(msg)
 
     def _select_all(self, selector: str) -> list[HtmlElement]:
         return self.root.cssselect(selector)

--- a/src/comics/browser/views.py
+++ b/src/comics/browser/views.py
@@ -582,7 +582,7 @@ class OneComicMixin:
         )
 
     def get_feed_title(self):
-        return "Comics from %s" % self.comic.name
+        return f"Comics from {self.comic.name}"
 
     def get_first_url(self):
         try:

--- a/src/comics/comics/anleggsplassen.py
+++ b/src/comics/comics/anleggsplassen.py
@@ -41,7 +41,7 @@ class Crawler(CrawlerBase):
             if date != pub_date:
                 continue
 
-            img = article_page.root.xpath('//img[@title="%s"]/@src' % title)
+            img = article_page.root.xpath(f'//img[@title="{title}"]/@src')
             url = str(img[0])
 
             return CrawlerImage(url, title, text)

--- a/src/comics/comics/awkwardzombie.py
+++ b/src/comics/comics/awkwardzombie.py
@@ -21,9 +21,9 @@ class Crawler(CrawlerBase):
             page_url = "https://www.awkwardzombie.com/awkward-zombie/archive/"
             self.archive_page = self.parse_page(page_url)
 
+        date_string = pub_date.strftime("%m-%d-%y")
         release = self.archive_page.root.xpath(
-            "//div[(@class='archive-date') and contains(.,'%s')]/.."
-            % pub_date.strftime("%m-%d-%y")
+            f"//div[(@class='archive-date') and contains(.,'{date_string}')]/.."
         )
         if not release:
             return

--- a/src/comics/comics/gucomics.py
+++ b/src/comics/comics/gucomics.py
@@ -19,7 +19,7 @@ class Crawler(CrawlerBase):
     time_zone = "America/New_York"
 
     def crawl(self, pub_date):
-        page_url = "http://www.gucomics.com/%s" % pub_date.strftime("%Y%m%d")
+        page_url = f"http://www.gucomics.com/{pub_date:%Y%m%d}"
         page = self.parse_page(page_url)
 
         title = page.texts("b")[0]

--- a/src/comics/comics/joyoftech.py
+++ b/src/comics/comics/joyoftech.py
@@ -31,7 +31,7 @@ class Crawler(CrawlerBase):
             num = matches.group(1)
 
             page = self.parse_page(entry.link)
-            url = page.src('img[src*="/joyimages/%s"]' % num)
+            url = page.src(f'img[src*="/joyimages/{num}"]')
             if not url:
                 continue
             return CrawlerImage(url, title)

--- a/src/comics/comics/leasticoulddo.py
+++ b/src/comics/comics/leasticoulddo.py
@@ -16,7 +16,7 @@ class Crawler(CrawlerBase):
     time_zone = "America/Montreal"
 
     def crawl(self, pub_date):
-        url = "https://leasticoulddo.com/comic/%s" % pub_date.strftime("%Y%m%d")
+        url = f"https://leasticoulddo.com/comic/{pub_date:%Y%m%d}"
         page = self.parse_page(url)
         image_url = page.src('img[class="comic"]')
 

--- a/src/comics/comics/lunche24.py
+++ b/src/comics/comics/lunche24.py
@@ -16,7 +16,5 @@ class Crawler(CrawlerBase):
     time_zone = "Europe/Oslo"
 
     def crawl(self, pub_date):
-        url = "https://api.e24.no/content/v1/comics/%s" % (
-            pub_date.strftime("%Y-%m-%d")
-        )
+        url = f"https://api.e24.no/content/v1/comics/{pub_date:%Y-%m-%d}"
         return CrawlerImage(url)

--- a/src/comics/comics/lunchtu.py
+++ b/src/comics/comics/lunchtu.py
@@ -20,6 +20,6 @@ class Crawler(CrawlerBase):
 
     def crawl(self, pub_date):
         url = (
-            "https://www.tu.no/api/widgets/comics?name=lunch&date=%s"
-        ) % pub_date.strftime("%Y-%m-%d")
+            f"https://www.tu.no/api/widgets/comics?name=lunch&date={pub_date:%Y-%m-%d}"
+        )
         return CrawlerImage(url)

--- a/src/comics/comics/notinventedhere.py
+++ b/src/comics/comics/notinventedhere.py
@@ -18,7 +18,6 @@ class Crawler(CrawlerBase):
 
     def crawl(self, pub_date):
         url = (
-            "https://s3.amazonaws.com/thiswas.notinventedhe.re/on/%s"
-            % pub_date.strftime("%Y-%m-%d")
+            f"https://s3.amazonaws.com/thiswas.notinventedhe.re/on/{pub_date:%Y-%m-%d}"
         )
         return CrawlerImage(url)

--- a/src/comics/comics/optipess.py
+++ b/src/comics/comics/optipess.py
@@ -18,14 +18,13 @@ class Crawler(CrawlerBase):
     def crawl(self, pub_date):
         # Find the post for the requested date
         archive_page = self.parse_page(
-            "https://www.optipess.com/archive/?archive_year=%s"
-            % pub_date.strftime("%Y")
+            f"https://www.optipess.com/archive/?archive_year={pub_date:%Y}"
         )
         date_string = pub_date.strftime("%b %-d")
 
         post_link = archive_page.root.xpath(
             '//td[(@class="archive-date") and '
-            '(.="%s")]/../td[@class="archive-title"]/a' % date_string
+            f'(.="{date_string}")]/../td[@class="archive-title"]/a'
         )
 
         if not post_link:

--- a/src/comics/comics/wulffmorgenthaler.py
+++ b/src/comics/comics/wulffmorgenthaler.py
@@ -19,9 +19,9 @@ class Crawler(CrawlerBase):
     headers = {"User-Agent": "Mozilla/4.0"}
 
     def crawl(self, pub_date):
-        page_url = "http://wumo.com/wumo/%s" % pub_date.strftime("%Y/%m/%d")
+        page_url = f"http://wumo.com/wumo/{pub_date:%Y/%m/%d}"
         page = self.parse_page(page_url)
-        urls = page.srcs('img[src*="/img/wumo/%s"]' % pub_date.strftime("%Y/%m"))
+        urls = page.srcs(f'img[src*="/img/wumo/{pub_date:%Y/%m}"]')
         if not urls:
             return
         return CrawlerImage(urls[0])

--- a/src/comics/core/comic_data.py
+++ b/src/comics/core/comic_data.py
@@ -82,9 +82,8 @@ class ComicDataLoader:
         logger.debug("Importing comic module for %s", comic_slug)
         comic_module = get_comic_module(comic_slug)
         if not hasattr(comic_module, "ComicData"):
-            raise ComicDataError(
-                "%s does not have a ComicData class" % comic_module.__name__
-            )
+            msg = f"{comic_module.__name__} does not have a ComicData class"
+            raise ComicDataError(msg)
         data = comic_module.ComicData()
         assert isinstance(data, ComicDataBase)
         return data

--- a/src/comics/core/exceptions.py
+++ b/src/comics/core/exceptions.py
@@ -5,11 +5,11 @@ class ComicsError(Exception):
         self.value = value
 
     def __str__(self):
-        return "Generic comics error (%s)" % self.value
+        return f"Generic comics error ({self.value})"
 
 
 class ComicDataError(ComicsError):
     """Base class for comic data exceptions"""
 
     def __str__(self):
-        return "Comics data error (%s)" % self.value
+        return f"Comics data error ({self.value})"

--- a/src/comics/help/views.py
+++ b/src/comics/help/views.py
@@ -20,13 +20,13 @@ def feedback(request):
     if request.method == "POST":
         form = FeedbackForm(request.POST)
         if form.is_valid():
-            subject = "Feedback from %s" % settings.COMICS_SITE_TITLE
+            subject = f"Feedback from {settings.COMICS_SITE_TITLE}"
 
-            metadata = "Client IP address: %s\n" % request.META["REMOTE_ADDR"]
-            metadata += "User agent: %s\n" % request.headers["user-agent"]
+            metadata = f"Client IP address: {request.META['REMOTE_ADDR']}\n"
+            metadata += f"User agent: {request.headers['user-agent']}\n"
             metadata += f"User: {request.user.username} <{request.user.email}>\n"
 
-            message = "{}\n\n-- \n{}".format(form.cleaned_data["message"], metadata)
+            message = f"{form.cleaned_data['message']}\n\n-- \n{metadata}"
 
             mail = EmailMessage(
                 subject=subject,

--- a/src/comics/settings.py
+++ b/src/comics/settings.py
@@ -293,8 +293,8 @@ ACCOUNT_LOGIN_METHODS = {"email"}
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 #
 # Sending email
-ACCOUNT_EMAIL_SUBJECT_PREFIX = "[%s] " % (
-    env.str("COMICS_SITE_TITLE", default="example.com")
+ACCOUNT_EMAIL_SUBJECT_PREFIX = (
+    f"[{env.str('COMICS_SITE_TITLE', default='example.com')}] "
 )
 ACCOUNT_EMAIL_UNKNOWN_ACCOUNTS = False
 

--- a/src/comics/urls.py
+++ b/src/comics/urls.py
@@ -36,7 +36,7 @@ urlpatterns = [
 if not settings.MEDIA_URL.startswith("http"):
     urlpatterns += [
         re_path(
-            r"^%s(?P<path>.*)$" % re.escape(settings.MEDIA_URL.lstrip("/")),
+            rf"^{re.escape(settings.MEDIA_URL.lstrip('/'))}(?P<path>.*)$",
             serve,
             kwargs={"document_root": settings.MEDIA_ROOT},
         ),

--- a/tests/api/test_subscriptions.py
+++ b/tests/api/test_subscriptions.py
@@ -41,8 +41,8 @@ def test_list_subscriptions(
     assert len(data["objects"]) == 2
 
     sub = data["objects"][0]
-    assert sub["resource_uri"] == ("/api/v1/subscriptions/%d/" % subscription.pk)
-    assert sub["comic"] == ("/api/v1/comics/%d/" % subscription.comic.pk)
+    assert sub["resource_uri"] == f"/api/v1/subscriptions/{subscription.pk}/"
+    assert sub["comic"] == f"/api/v1/comics/{subscription.comic.pk}/"
 
 
 def test_comic_filter(
@@ -63,7 +63,7 @@ def test_comic_filter(
     assert len(data["objects"]) == 1
 
     sub = data["objects"][0]
-    assert sub["resource_uri"] == ("/api/v1/subscriptions/%d/" % subscription.pk)
+    assert sub["resource_uri"] == f"/api/v1/subscriptions/{subscription.pk}/"
     assert sub["comic"] == "/api/v1/comics/9/"
 
 
@@ -81,14 +81,14 @@ def test_details_view(
 
     data = json.loads(response.content)
     sub = data["objects"][0]
-    assert sub["resource_uri"] == ("/api/v1/subscriptions/%d/" % subscription.pk)
+    assert sub["resource_uri"] == f"/api/v1/subscriptions/{subscription.pk}/"
 
     response = client.get(
         sub["resource_uri"], headers={"authorization": "Key s3cretk3y"}
     )
 
     data = json.loads(response.content)
-    assert data["comic"] == ("/api/v1/comics/%d/" % subscription.comic.pk)
+    assert data["comic"] == f"/api/v1/comics/{subscription.comic.pk}/"
 
 
 def test_subscribe_to_comic(
@@ -99,7 +99,7 @@ def test_subscribe_to_comic(
 ) -> None:
     comic = Comic.objects.get(slug="bunny")
 
-    data = json.dumps({"comic": "/api/v1/comics/%d/" % comic.pk})
+    data = json.dumps({"comic": f"/api/v1/comics/{comic.pk}/"})
     response = client.post(
         "/api/v1/subscriptions/",
         data=data,
@@ -110,7 +110,7 @@ def test_subscribe_to_comic(
     assert response.status_code == 201
 
     subscription = Subscription.objects.get(userprofile__user=user, comic=comic)
-    assert response["Location"] == ("/api/v1/subscriptions/%d/" % subscription.pk)
+    assert response["Location"] == f"/api/v1/subscriptions/{subscription.pk}/"
 
     assert response.content == b""
 
@@ -126,7 +126,7 @@ def test_unsubscribe_from_comic(
     assert Subscription.objects.filter(userprofile__user=user).count() == 2
 
     response = client.delete(
-        "/api/v1/subscriptions/%d/" % sub.pk,
+        f"/api/v1/subscriptions/{sub.pk}/",
         headers={"authorization": "Key s3cretk3y"},
     )
 
@@ -147,8 +147,8 @@ def test_bulk_update(
 
     data = json.dumps(
         {
-            "objects": [{"comic": "/api/v1/comics/%d/" % comic.pk}],
-            "deleted_objects": ["/api/v1/subscriptions/%d/" % deleted.pk],
+            "objects": [{"comic": f"/api/v1/comics/{comic.pk}/"}],
+            "deleted_objects": [f"/api/v1/subscriptions/{deleted.pk}/"],
         }
     )
     response = client.patch(
@@ -180,7 +180,7 @@ def test_cannot_read_other_users_subscription(
     )
 
     response = client.get(
-        "/api/v1/subscriptions/%d/" % bob_sub.pk,
+        f"/api/v1/subscriptions/{bob_sub.pk}/",
         headers={"authorization": "Key s3cretk3y"},
     )
 
@@ -200,7 +200,7 @@ def test_cannot_delete_other_users_subscription(
     )
 
     response = client.delete(
-        "/api/v1/subscriptions/%d/" % bob_sub.pk,
+        f"/api/v1/subscriptions/{bob_sub.pk}/",
         headers={"authorization": "Key s3cretk3y"},
     )
 

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -60,7 +60,7 @@ def test_cannot_read_other_users_details(db: None, client: Client, user: User) -
     bob = User.objects.create_user("bob", "bob@example.com", "topsecret")
 
     response = client.get(
-        "/api/v1/users/%d/" % bob.pk,
+        f"/api/v1/users/{bob.pk}/",
         headers={"authorization": "Key s3cretk3y"},
     )
 


### PR DESCRIPTION
Convert printf-style string formatting to f-strings across the application and the API tests, and remove the UP031 ignore so that ruff enforces f-strings from now on.