### PR TITLE
build: Derive version from git tags instead of pyproject.toml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,9 @@ build:
   tools:
     python: "3.12"
   jobs:
+    post_checkout:
+      # Fetch full history and tags so the version can be derived from git tags
+      - git fetch --unshallow --tags || true
     post_create_environment:
       - pip install uv
     post_install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,14 +1,12 @@
 # noqa: INP001
 
-import pathlib
-import tomllib
+from importlib.metadata import version as get_version
 
 project = "Comics"
 author = "Stein Magnus Jodal and contributors"
 copyright = f"2009-2026, {author}"  # noqa: A001
 
-with pathlib.Path("../pyproject.toml").open("rb") as fh:
-    release = tomllib.load(fh)["project"]["version"]
+release = get_version("comics")
 version = ".".join(release.split(".")[:2])
 
 extensions = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comics"
-version = "25.8.4"
+dynamic = ["version"]
 description = "Comics is a webcomics aggregator."
 authors = [{ name = "Stein Magnus Jodal", email = "stein.magnus@jodal.no" }]
 readme = "README.md"
@@ -254,18 +254,29 @@ commands = [["zizmor", "{posargs:.}"]]
 
 [tool.uv]
 package = true
+# Re-derive the version when the git commit or tags change
+cache-keys = [{ git = { commit = true, tags = true } }]
 
-[tool.uv.build-backend]
-source-include = [
+
+[tool.hatch.build.targets.sdist]
+include = [
     ".github/**",
     ".gitignore",
     ".mailmap",
     "dev-template.env",
     "docs/**",
+    "src/**",
     "tests/**",
 ]
 
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+
+[tool.uv-dynamic-versioning]
+fallback-version = "0.0.0"
+
 
 [build-system]
-requires = ["uv_build>=0.11.26,<0.12.0"]
-build-backend = "uv_build"
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"

--- a/uv.lock
+++ b/uv.lock
@@ -222,7 +222,6 @@ wheels = [
 
 [[package]]
 name = "comics"
-version = "25.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "cssselect" },


### PR DESCRIPTION
So we dont have to maintain the version in `pyproject.toml`.