### PR TITLE
fix: Trust X-Forwarded-Proto from the reverse proxy

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -321,6 +321,15 @@ Caddy terminates HTTPS, serves media straight from disk, and proxies the rest to
 the app. Static files are served by WhiteNoise from inside the app, so Caddy does
 not need to handle ``/static/``.
 
+The app trusts the ``X-Forwarded-Proto`` header to detect that a request
+arrived over HTTPS. Caddy sets the header on every proxied request and ignores
+any value sent by clients, so this works out of the box. If you use another
+reverse proxy, make sure it does the same, or point the app at the right
+header, e.g. ``DJANGO_SECURE_PROXY_SSL_HEADER=HTTP_X_FORWARDED_SCHEME,https``.
+If clients can reach the app without passing through such a proxy, disable the
+trust entirely by setting ``DJANGO_SECURE_PROXY_SSL_HEADER`` to an empty
+value.
+
 .. code-block:: text
 
     comics.example.com {

--- a/src/comics/settings.py
+++ b/src/comics/settings.py
@@ -68,6 +68,27 @@ SECRET_KEY = env.str(
 ALLOWED_HOSTS = env.list("DJANGO_ALLOWED_HOSTS", default=["*"])
 
 
+# Security - HTTPS detection
+#
+# In the documented deployment, a reverse proxy terminates HTTPS and proxies
+# to the app over plain HTTP, setting the X-Forwarded-Proto header on every
+# request. Trust that header by default so that request.is_secure() and
+# absolute URLs built from requests use the right scheme. Only keep this
+# enabled if all requests pass through a proxy that sets or strips the
+# header. Set to an empty value to disable.
+SECURE_PROXY_SSL_HEADER = (
+    tuple(
+        value
+        for value in env.list(
+            "DJANGO_SECURE_PROXY_SSL_HEADER",
+            default=["HTTP_X_FORWARDED_PROTO", "https"],
+        )
+        if value
+    )
+    or None
+)
+
+
 # Security - Cross-Site Request Forgery (CSRF)
 #
 # Set this to match your site's base URL, including port if not 80 or 443.


### PR DESCRIPTION
The documented deployment terminates HTTPS in Caddy, which proxies to the app over plain HTTP. Without SECURE_PROXY_SSL_HEADER, Django considered every request insecure and built absolute URLs, e.g. in Atom feeds, with the http scheme.

Caddy sets X-Forwarded-Proto on every proxied request and ignores the header from untrusted clients, so trust it by default. The header can be changed or trust disabled with DJANGO_SECURE_PROXY_SSL_HEADER.