### PR TITLE
Use type-safe queryset methods instead of custom ORM queries

### DIFF
--- a/src/comics/accounts/querysets.py
+++ b/src/comics/accounts/querysets.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 
 from comics.core.querysets import BaseQuerySet
 
 if TYPE_CHECKING:
+    from django.contrib.auth.models import User
+
     from comics.accounts.models import Subscription, UserProfile  # noqa: F401
+    from comics.core.models import Comic
 
 
 class UserProfileQuerySet(BaseQuerySet["UserProfile"]):
@@ -13,4 +16,8 @@ class UserProfileQuerySet(BaseQuerySet["UserProfile"]):
 
 
 class SubscriptionQuerySet(BaseQuerySet["Subscription"]):
-    pass
+    def for_user(self, user: User, /) -> Self:
+        return self.filter(userprofile__user=user)
+
+    def for_comic(self, comic: Comic, /) -> Self:
+        return self.filter(comic=comic)

--- a/src/comics/accounts/views.py
+++ b/src/comics/accounts/views.py
@@ -62,9 +62,7 @@ def mycomics_toggle_comic(request: AuthenticatedHttpRequest) -> HttpResponse:
         if not _is_js_request(request):
             messages.info(request, f'Added "{comic.name}" to my comics')
     elif "remove_comic" in request.POST:
-        subscriptions = Subscription.objects.filter(
-            userprofile=request.user.comics_profile, comic=comic
-        )
+        subscriptions = Subscription.objects.for_user(request.user).for_comic(comic)
         subscriptions.delete()
         if not _is_js_request(request):
             messages.info(request, f'Removed "{comic.name}" from my comics')
@@ -88,9 +86,7 @@ def mycomics_edit_comics(request: AuthenticatedHttpRequest) -> HttpResponse:
 
     for comic in my_comics:
         if comic.slug not in request.POST:
-            subscriptions = Subscription.objects.filter(
-                userprofile=request.user.comics_profile, comic=comic
-            )
+            subscriptions = Subscription.objects.for_user(request.user).for_comic(comic)
             subscriptions.delete()
             if not _is_js_request(request):
                 messages.info(request, f'Removed "{comic.name}" from my comics')

--- a/src/comics/accounts/views.py
+++ b/src/comics/accounts/views.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import render
 from django.urls import reverse
 from invitations.utils import get_invitation_model
 
@@ -54,7 +54,7 @@ def mycomics_toggle_comic(request: AuthenticatedHttpRequest) -> HttpResponse:
 
     comic_slug = request.POST["comic"]
     assert isinstance(comic_slug, str)
-    comic = get_object_or_404(Comic.objects.for_slug(comic_slug))
+    comic = Comic.objects.for_slug(comic_slug).get_or_404()
 
     if "add_comic" in request.POST:
         subscription = Subscription(

--- a/src/comics/accounts/views.py
+++ b/src/comics/accounts/views.py
@@ -52,7 +52,9 @@ def mycomics_toggle_comic(request: AuthenticatedHttpRequest) -> HttpResponse:
         response["Allowed"] = "POST"
         return response
 
-    comic = get_object_or_404(Comic, slug=request.POST["comic"])
+    comic_slug = request.POST["comic"]
+    assert isinstance(comic_slug, str)
+    comic = get_object_or_404(Comic.objects.for_slug(comic_slug))
 
     if "add_comic" in request.POST:
         subscription = Subscription(

--- a/src/comics/aggregator/command.py
+++ b/src/comics/aggregator/command.py
@@ -174,12 +174,11 @@ class AggregatorConfig:
     def _get_comic_by_slug(cls, comic_slug: str) -> Comic:
         from comics.core.models import Comic  # noqa: PLC0415
 
-        try:
-            comic = Comic.objects.for_slug(comic_slug).get()
-        except Comic.DoesNotExist as exc:
+        comic = Comic.objects.for_slug(comic_slug).get_or_none()
+        if comic is None:
             error_msg = f"Comic {comic_slug} not found"
             logger.error(error_msg)
-            raise ComicsError(error_msg) from exc
+            raise ComicsError(error_msg)
         return comic
 
     @classmethod

--- a/src/comics/aggregator/command.py
+++ b/src/comics/aggregator/command.py
@@ -175,7 +175,7 @@ class AggregatorConfig:
         from comics.core.models import Comic  # noqa: PLC0415
 
         try:
-            comic = Comic.objects.get(slug=comic_slug)
+            comic = Comic.objects.for_slug(comic_slug).get()
         except Comic.DoesNotExist as exc:
             error_msg = f"Comic {comic_slug} not found"
             logger.error(error_msg)

--- a/src/comics/aggregator/crawler.py
+++ b/src/comics/aggregator/crawler.py
@@ -144,7 +144,7 @@ class CrawlerBase:
 
         if (
             self.multiple_releases_per_day is False
-            and self.comic.release_set.filter(pub_date=pub_date).count() > 0
+            and self.comic.release_set.filter(pub_date=pub_date).exists()
         ):
             raise ReleaseAlreadyExists(identifier)
 

--- a/src/comics/aggregator/crawler.py
+++ b/src/comics/aggregator/crawler.py
@@ -144,7 +144,7 @@ class CrawlerBase:
 
         if (
             self.multiple_releases_per_day is False
-            and self.comic.release_set.filter(pub_date=pub_date).exists()
+            and self.comic.release_set.published_on(pub_date).exists()
         ):
             raise ReleaseAlreadyExists(identifier)
 

--- a/src/comics/aggregator/downloader.py
+++ b/src/comics/aggregator/downloader.py
@@ -136,14 +136,10 @@ class ImageDownloader:
         has_rerun_releases: bool,
         checksum: str,
     ) -> Image | None:
-        try:
-            image = Image.objects.for_comic(comic).for_checksum(checksum).get()
-        except Image.DoesNotExist:
-            return None
-        else:
-            if not has_rerun_releases:
-                raise ImageAlreadyExists(self.identifier)
-            return image
+        image = Image.objects.for_comic(comic).for_checksum(checksum).get_or_none()
+        if image is not None and not has_rerun_releases:
+            raise ImageAlreadyExists(self.identifier)
+        return image
 
     def _validate_image(self, image_file: IO[bytes]) -> PILImageFile:
         try:

--- a/src/comics/aggregator/downloader.py
+++ b/src/comics/aggregator/downloader.py
@@ -137,7 +137,7 @@ class ImageDownloader:
         checksum: str,
     ) -> Image | None:
         try:
-            image = Image.objects.get(comic=comic, checksum=checksum)
+            image = Image.objects.for_comic(comic).for_checksum(checksum).get()
         except Image.DoesNotExist:
             return None
         else:

--- a/src/comics/api/views.py
+++ b/src/comics/api/views.py
@@ -15,7 +15,6 @@ from typing import TYPE_CHECKING, Any, Protocol, Self, cast
 from django.contrib.auth.models import User
 from django.db import transaction
 from django.http import Http404, HttpResponse
-from django.shortcuts import get_object_or_404
 from ninja import NinjaAPI
 from ninja.errors import AuthenticationError, HttpError
 
@@ -447,7 +446,7 @@ def comics_list(request: AuthedRequest) -> HttpResponse:
 @api.get("/comics/{int:comic_id}/", auth=key_auth)
 def comics_detail(request: HttpRequest, comic_id: int) -> HttpResponse:
     """Show a comic."""
-    comic = get_object_or_404(Comic.objects.for_pk(comic_id))
+    comic = Comic.objects.for_pk(comic_id).get_or_404()
     return json_response(comic_dict(comic))
 
 
@@ -472,7 +471,7 @@ def images_list(request: HttpRequest) -> HttpResponse:
 @api.get("/images/{int:image_id}/", auth=key_auth)
 def images_detail(request: HttpRequest, image_id: int) -> HttpResponse:
     """Show a comic image."""
-    image = get_object_or_404(Image.objects.for_pk(image_id))
+    image = Image.objects.for_pk(image_id).get_or_404()
     return json_response(image_dict(image))
 
 
@@ -505,9 +504,7 @@ def releases_list(request: AuthedRequest) -> HttpResponse:
 @api.get("/releases/{int:release_id}/", auth=key_auth)
 def releases_detail(request: HttpRequest, release_id: int) -> HttpResponse:
     """Show a comic release, including its images."""
-    release = get_object_or_404(
-        Release.objects.select_related("comic").for_pk(release_id)
-    )
+    release = Release.objects.select_related("comic").for_pk(release_id).get_or_404()
     return json_response(release_dict(release))
 
 
@@ -530,10 +527,9 @@ def parse_body(request: HttpRequest) -> dict[str, Any]:
 def comic_from_uri(uri: str | None) -> Comic:
     match = COMIC_URI_RE.match(uri or "")
     if match:
-        try:
-            return Comic.objects.for_pk(int(match[1])).get()
-        except Comic.DoesNotExist:
-            pass
+        comic = Comic.objects.for_pk(int(match[1])).get_or_none()
+        if comic is not None:
+            return comic
     raise HttpError(400, f"Unknown comic '{uri}'")
 
 
@@ -544,7 +540,9 @@ def own_subscription_from_uri(
     match = SUBSCRIPTION_URI_RE.match(uri or "")
     if match is None:
         return None
-    return Subscription.objects.for_user(request.auth).for_pk(int(match[1])).first()
+    return (
+        Subscription.objects.for_user(request.auth).for_pk(int(match[1])).get_or_none()
+    )
 
 
 @api.get(
@@ -617,8 +615,8 @@ def subscriptions_bulk_update(request: AuthedRequest) -> HttpResponse:
 @api.get("/subscriptions/{int:subscription_id}/", auth=key_auth)
 def subscriptions_detail(request: AuthedRequest, subscription_id: int) -> HttpResponse:
     """Show one of the authenticated user's subscriptions."""
-    subscription = get_object_or_404(
-        Subscription.objects.for_user(request.auth).for_pk(subscription_id)
+    subscription = (
+        Subscription.objects.for_user(request.auth).for_pk(subscription_id).get_or_404()
     )
     return json_response(subscription_dict(subscription))
 
@@ -630,8 +628,8 @@ def subscriptions_detail(request: AuthedRequest, subscription_id: int) -> HttpRe
 )
 def subscriptions_update(request: AuthedRequest, subscription_id: int) -> HttpResponse:
     """Change one of the authenticated user's subscriptions to another comic."""
-    subscription = get_object_or_404(
-        Subscription.objects.for_user(request.auth).for_pk(subscription_id)
+    subscription = (
+        Subscription.objects.for_user(request.auth).for_pk(subscription_id).get_or_404()
     )
     data = parse_body(request)
     subscription.comic = comic_from_uri(data.get("comic"))
@@ -642,8 +640,8 @@ def subscriptions_update(request: AuthedRequest, subscription_id: int) -> HttpRe
 @api.delete("/subscriptions/{int:subscription_id}/", auth=key_auth)
 def subscriptions_delete(request: AuthedRequest, subscription_id: int) -> HttpResponse:
     """Unsubscribe the authenticated user from a comic."""
-    subscription = get_object_or_404(
-        Subscription.objects.for_user(request.auth).for_pk(subscription_id)
+    subscription = (
+        Subscription.objects.for_user(request.auth).for_pk(subscription_id).get_or_404()
     )
     subscription.delete()
     return HttpResponse(status=204)

--- a/src/comics/api/views.py
+++ b/src/comics/api/views.py
@@ -32,7 +32,6 @@ from comics.api.serialization import format_value, json_response, paginated
 from comics.core.models import Comic, Image, Release
 
 if TYPE_CHECKING:
-    from django.contrib.auth.models import User
     from django.http import HttpRequest
 
     from comics.accounts.typing import ComicsUser
@@ -448,7 +447,7 @@ def comics_list(request: AuthedRequest) -> HttpResponse:
 @api.get("/comics/{int:comic_id}/", auth=key_auth)
 def comics_detail(request: HttpRequest, comic_id: int) -> HttpResponse:
     """Show a comic."""
-    comic = get_object_or_404(Comic, pk=comic_id)
+    comic = get_object_or_404(Comic.objects.for_pk(comic_id))
     return json_response(comic_dict(comic))
 
 
@@ -473,7 +472,7 @@ def images_list(request: HttpRequest) -> HttpResponse:
 @api.get("/images/{int:image_id}/", auth=key_auth)
 def images_detail(request: HttpRequest, image_id: int) -> HttpResponse:
     """Show a comic image."""
-    image = get_object_or_404(Image, pk=image_id)
+    image = get_object_or_404(Image.objects.for_pk(image_id))
     return json_response(image_dict(image))
 
 
@@ -506,7 +505,9 @@ def releases_list(request: AuthedRequest) -> HttpResponse:
 @api.get("/releases/{int:release_id}/", auth=key_auth)
 def releases_detail(request: HttpRequest, release_id: int) -> HttpResponse:
     """Show a comic release, including its images."""
-    release = get_object_or_404(Release.objects.select_related("comic"), pk=release_id)
+    release = get_object_or_404(
+        Release.objects.select_related("comic").for_pk(release_id)
+    )
     return json_response(release_dict(release))
 
 
@@ -530,7 +531,7 @@ def comic_from_uri(uri: str | None) -> Comic:
     match = COMIC_URI_RE.match(uri or "")
     if match:
         try:
-            return Comic.objects.get(pk=int(match[1]))
+            return Comic.objects.for_pk(int(match[1])).get()
         except Comic.DoesNotExist:
             pass
     raise HttpError(400, f"Unknown comic '{uri}'")
@@ -543,7 +544,7 @@ def own_subscription_from_uri(
     match = SUBSCRIPTION_URI_RE.match(uri or "")
     if match is None:
         return None
-    return Subscription.objects.for_user(request.auth).filter(pk=int(match[1])).first()
+    return Subscription.objects.for_user(request.auth).for_pk(int(match[1])).first()
 
 
 @api.get(
@@ -617,7 +618,7 @@ def subscriptions_bulk_update(request: AuthedRequest) -> HttpResponse:
 def subscriptions_detail(request: AuthedRequest, subscription_id: int) -> HttpResponse:
     """Show one of the authenticated user's subscriptions."""
     subscription = get_object_or_404(
-        Subscription.objects.for_user(request.auth), pk=subscription_id
+        Subscription.objects.for_user(request.auth).for_pk(subscription_id)
     )
     return json_response(subscription_dict(subscription))
 
@@ -630,7 +631,7 @@ def subscriptions_detail(request: AuthedRequest, subscription_id: int) -> HttpRe
 def subscriptions_update(request: AuthedRequest, subscription_id: int) -> HttpResponse:
     """Change one of the authenticated user's subscriptions to another comic."""
     subscription = get_object_or_404(
-        Subscription.objects.for_user(request.auth), pk=subscription_id
+        Subscription.objects.for_user(request.auth).for_pk(subscription_id)
     )
     data = parse_body(request)
     subscription.comic = comic_from_uri(data.get("comic"))
@@ -642,7 +643,7 @@ def subscriptions_update(request: AuthedRequest, subscription_id: int) -> HttpRe
 def subscriptions_delete(request: AuthedRequest, subscription_id: int) -> HttpResponse:
     """Unsubscribe the authenticated user from a comic."""
     subscription = get_object_or_404(
-        Subscription.objects.for_user(request.auth), pk=subscription_id
+        Subscription.objects.for_user(request.auth).for_pk(subscription_id)
     )
     subscription.delete()
     return HttpResponse(status=204)

--- a/src/comics/api/views.py
+++ b/src/comics/api/views.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, Self, cast
 
 from django.contrib.auth.models import User
 from django.db import transaction
@@ -32,7 +32,7 @@ from comics.api.serialization import format_value, json_response, paginated
 from comics.core.models import Comic, Image, Release
 
 if TYPE_CHECKING:
-    from django.db.models import Model, QuerySet
+    from django.contrib.auth.models import User
     from django.http import HttpRequest
 
     from comics.accounts.typing import ComicsUser
@@ -216,16 +216,22 @@ USER_SPEC = FilterSpec(
 )
 
 
-def subscribed_filter[M: Model](
+class SubscribableQuerySet(Protocol):
+    """A queryset that can be narrowed by a user's subscriptions."""
+
+    def subscribed_by(self, user: User, /) -> Self: ...
+    def not_subscribed_by(self, user: User, /) -> Self: ...
+
+
+def subscribed_filter[QS: SubscribableQuerySet](
     request: AuthedRequest,
-    queryset: QuerySet[M],
-    lookup: str,
-) -> QuerySet[M]:
+    queryset: QS,
+) -> QS:
     subscribed = request.GET.get("subscribed")
     if subscribed == "true":
-        return queryset.filter(**{lookup: request.auth})
+        return queryset.subscribed_by(request.auth)
     if subscribed == "false":
-        return queryset.exclude(**{lookup: request.auth})
+        return queryset.not_subscribed_by(request.auth)
     return queryset
 
 
@@ -434,8 +440,8 @@ def users_detail(request: AuthedRequest, user_id: int) -> HttpResponse:
 )
 def comics_list(request: AuthedRequest) -> HttpResponse:
     """List all comics known to the site."""
-    queryset = apply_filters(request.GET, Comic.objects.all(), COMIC_SPEC)
-    queryset = subscribed_filter(request, queryset, "userprofile__user")
+    queryset = subscribed_filter(request, Comic.objects.all())
+    queryset = apply_filters(request.GET, queryset, COMIC_SPEC)
     return json_response(paginated(request, queryset, comic_dict))
 
 
@@ -492,8 +498,8 @@ def releases_list(request: AuthedRequest) -> HttpResponse:
         .prefetch_related("images")
         .order_by("-fetched")
     )
+    queryset = subscribed_filter(request, queryset)
     queryset = apply_filters(request.GET, queryset, RELEASE_SPEC)
-    queryset = subscribed_filter(request, queryset, "comic__userprofile__user")
     return json_response(paginated(request, queryset, release_dict))
 
 

--- a/src/comics/api/views.py
+++ b/src/comics/api/views.py
@@ -35,7 +35,6 @@ if TYPE_CHECKING:
     from django.db.models import Model, QuerySet
     from django.http import HttpRequest
 
-    from comics.accounts.querysets import SubscriptionQuerySet
     from comics.accounts.typing import ComicsUser
 
     class AuthedRequest(HttpRequest):
@@ -511,10 +510,6 @@ SUBSCRIPTION_URI_RE = re.compile(rf"^{re.escape(API_PREFIX)}/subscriptions/(\d+)
 COMIC_URI_RE = re.compile(rf"^{re.escape(API_PREFIX)}/comics/(\d+)/$")
 
 
-def own_subscriptions(request: AuthedRequest) -> SubscriptionQuerySet:
-    return Subscription.objects.for_user(request.auth)
-
-
 def parse_body(request: HttpRequest) -> dict[str, Any]:
     try:
         data = json.loads(request.body)
@@ -542,7 +537,7 @@ def own_subscription_from_uri(
     match = SUBSCRIPTION_URI_RE.match(uri or "")
     if match is None:
         return None
-    return own_subscriptions(request).filter(pk=int(match[1])).first()
+    return Subscription.objects.for_user(request.auth).filter(pk=int(match[1])).first()
 
 
 @api.get(
@@ -552,7 +547,9 @@ def own_subscription_from_uri(
 )
 def subscriptions_list(request: AuthedRequest) -> HttpResponse:
     """List the authenticated user's comic subscriptions."""
-    queryset = apply_filters(request.GET, own_subscriptions(request), SUBSCRIPTION_SPEC)
+    queryset = apply_filters(
+        request.GET, Subscription.objects.for_user(request.auth), SUBSCRIPTION_SPEC
+    )
     return json_response(paginated(request, queryset, subscription_dict))
 
 
@@ -613,7 +610,9 @@ def subscriptions_bulk_update(request: AuthedRequest) -> HttpResponse:
 @api.get("/subscriptions/{int:subscription_id}/", auth=key_auth)
 def subscriptions_detail(request: AuthedRequest, subscription_id: int) -> HttpResponse:
     """Show one of the authenticated user's subscriptions."""
-    subscription = get_object_or_404(own_subscriptions(request), pk=subscription_id)
+    subscription = get_object_or_404(
+        Subscription.objects.for_user(request.auth), pk=subscription_id
+    )
     return json_response(subscription_dict(subscription))
 
 
@@ -624,7 +623,9 @@ def subscriptions_detail(request: AuthedRequest, subscription_id: int) -> HttpRe
 )
 def subscriptions_update(request: AuthedRequest, subscription_id: int) -> HttpResponse:
     """Change one of the authenticated user's subscriptions to another comic."""
-    subscription = get_object_or_404(own_subscriptions(request), pk=subscription_id)
+    subscription = get_object_or_404(
+        Subscription.objects.for_user(request.auth), pk=subscription_id
+    )
     data = parse_body(request)
     subscription.comic = comic_from_uri(data.get("comic"))
     subscription.save()
@@ -634,6 +635,8 @@ def subscriptions_update(request: AuthedRequest, subscription_id: int) -> HttpRe
 @api.delete("/subscriptions/{int:subscription_id}/", auth=key_auth)
 def subscriptions_delete(request: AuthedRequest, subscription_id: int) -> HttpResponse:
     """Unsubscribe the authenticated user from a comic."""
-    subscription = get_object_or_404(own_subscriptions(request), pk=subscription_id)
+    subscription = get_object_or_404(
+        Subscription.objects.for_user(request.auth), pk=subscription_id
+    )
     subscription.delete()
     return HttpResponse(status=204)

--- a/src/comics/api/views.py
+++ b/src/comics/api/views.py
@@ -512,7 +512,7 @@ COMIC_URI_RE = re.compile(rf"^{re.escape(API_PREFIX)}/comics/(\d+)/$")
 
 
 def own_subscriptions(request: AuthedRequest) -> SubscriptionQuerySet:
-    return Subscription.objects.filter(userprofile__user=request.auth)
+    return Subscription.objects.for_user(request.auth)
 
 
 def parse_body(request: HttpRequest) -> dict[str, Any]:

--- a/src/comics/browser/feeds.py
+++ b/src/comics/browser/feeds.py
@@ -116,7 +116,7 @@ class OneComicFeed(ReleaseFeed[ComicForProfile]):
         **kwargs: Any,
     ) -> ComicForProfile:
         return ComicForProfile(
-            comic=get_object_or_404(Comic.objects.for_slug(kwargs["comic_slug"])),
+            comic=Comic.objects.for_slug(kwargs["comic_slug"]).get_or_404(),
             profile=_get_profile(request),
         )
 

--- a/src/comics/browser/feeds.py
+++ b/src/comics/browser/feeds.py
@@ -116,7 +116,7 @@ class OneComicFeed(ReleaseFeed[ComicForProfile]):
         **kwargs: Any,
     ) -> ComicForProfile:
         return ComicForProfile(
-            comic=get_object_or_404(Comic, slug=kwargs["comic_slug"]),
+            comic=get_object_or_404(Comic.objects.for_slug(kwargs["comic_slug"])),
             profile=_get_profile(request),
         )
 

--- a/src/comics/browser/feeds.py
+++ b/src/comics/browser/feeds.py
@@ -10,7 +10,7 @@ from django.http import HttpRequest
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils import feedgenerator, timezone
+from django.utils import feedgenerator
 from django.utils.formats import date_format
 
 from comics.core.models import Comic, Release
@@ -36,11 +36,6 @@ def _absolute_url(path: str) -> str:
     # object in the database instead of our settings.
     site_url: str = settings.COMICS_SITE_URL
     return urljoin(site_url, path)
-
-
-def _recent_releases(releases: ReleaseQuerySet) -> ReleaseQuerySet:
-    from_time = timezone.now() - dt.timedelta(days=settings.COMICS_MAX_DAYS_IN_FEED)
-    return releases.filter(fetched__gte=from_time).order_by("-fetched")
 
 
 class ReleaseFeed[ObjectT](Feed[Release, ObjectT]):
@@ -102,8 +97,7 @@ class MyComicsFeed(ReleaseFeed["UserProfile"]):
         )
 
     def items(self, obj: "UserProfile") -> ReleaseQuerySet:
-        releases = Release.objects.select_related().for_comics(*obj.comics.all())
-        return _recent_releases(releases)
+        return Release.objects.select_related().for_comics(*obj.comics.all()).for_feed()
 
 
 @dataclass
@@ -141,5 +135,4 @@ class OneComicFeed(ReleaseFeed[ComicForProfile]):
         )
 
     def items(self, obj: ComicForProfile) -> ReleaseQuerySet:
-        releases = Release.objects.select_related().for_comics(obj.comic)
-        return _recent_releases(releases)
+        return Release.objects.select_related().for_comics(obj.comic).for_feed()

--- a/src/comics/browser/feeds.py
+++ b/src/comics/browser/feeds.py
@@ -102,7 +102,7 @@ class MyComicsFeed(ReleaseFeed["UserProfile"]):
         )
 
     def items(self, obj: "UserProfile") -> ReleaseQuerySet:
-        releases = Release.objects.select_related().filter(comic__in=obj.comics.all())
+        releases = Release.objects.select_related().for_comics(*obj.comics.all())
         return _recent_releases(releases)
 
 
@@ -141,5 +141,5 @@ class OneComicFeed(ReleaseFeed[ComicForProfile]):
         )
 
     def items(self, obj: ComicForProfile) -> ReleaseQuerySet:
-        releases = Release.objects.select_related().filter(comic=obj.comic)
+        releases = Release.objects.select_related().for_comics(obj.comic)
         return _recent_releases(releases)

--- a/src/comics/browser/views.py
+++ b/src/comics/browser/views.py
@@ -50,7 +50,9 @@ class ComicMixin(View):
     @property
     def comic(self) -> Comic:
         if not hasattr(self, "_comic"):
-            self._comic = get_object_or_404(Comic, slug=self.kwargs["comic_slug"])
+            self._comic = get_object_or_404(
+                Comic.objects.for_slug(self.kwargs["comic_slug"])
+            )
         return self._comic
 
     def get_user(self) -> ComicsUser:

--- a/src/comics/browser/views.py
+++ b/src/comics/browser/views.py
@@ -317,7 +317,7 @@ class MyComicsNumReleasesSinceView(MyComicsLatestView):
     def get_num_releases_since(self) -> int:
         last_release_seen = get_object_or_404(Release, id=self.kwargs["release_id"])
         releases = super().get_queryset()
-        return releases.filter(fetched__gt=last_release_seen.fetched).count()
+        return releases.fetched_after(last_release_seen.fetched).count()
 
     def render_to_response(
         self,

--- a/src/comics/browser/views.py
+++ b/src/comics/browser/views.py
@@ -204,7 +204,7 @@ class MyComicsMixin(ReleaseMixin):
     def get_queryset(self) -> ReleaseQuerySet:
         return (
             Release.objects.select_related()
-            .filter(comic__in=self.get_my_comics())
+            .for_comics(*self.get_my_comics())
             .order_by("pub_date")
         )
 
@@ -220,40 +220,34 @@ class MyComicsMixin(ReleaseMixin):
     def get_today_url(self) -> str | None:
         return reverse("mycomics_today")
 
-    _last_pub_date: dt.date
+    _last_pub_date: dt.date | None
 
-    def _get_last_pub_date(self) -> dt.date:
+    def _get_last_pub_date(self) -> dt.date | None:
         if not hasattr(self, "_last_pub_date"):
-            self._last_pub_date = (
-                self.get_queryset()
-                .values_list("pub_date", flat=True)
-                .order_by("-pub_date")[0]
-            )
+            self._last_pub_date = self.get_queryset().last_pub_date()
         return self._last_pub_date
 
     def get_day_url(self) -> str | None:
-        try:
-            last_date = self._get_last_pub_date()
-            return reverse(
-                "mycomics_day",
-                kwargs={
-                    "year": last_date.year,
-                    "month": last_date.month,
-                    "day": last_date.day,
-                },
-            )
-        except IndexError:
+        last_date = self._get_last_pub_date()
+        if last_date is None:
             return None
+        return reverse(
+            "mycomics_day",
+            kwargs={
+                "year": last_date.year,
+                "month": last_date.month,
+                "day": last_date.day,
+            },
+        )
 
     def get_month_url(self) -> str | None:
-        try:
-            last_month = self._get_last_pub_date()
-            return reverse(
-                "mycomics_month",
-                kwargs={"year": last_month.year, "month": last_month.month},
-            )
-        except IndexError:
+        last_month = self._get_last_pub_date()
+        if last_month is None:
             return None
+        return reverse(
+            "mycomics_month",
+            kwargs={"year": last_month.year, "month": last_month.month},
+        )
 
     def get_feed_url(self) -> str | None:
         return "{}?key={}".format(
@@ -342,23 +336,16 @@ class MyComicsDayView(MyComicsMixin, ReleaseDayArchiveView):
     """View of releases from my comics for a given day"""
 
     def get_first_url(self) -> str | None:
-        try:
-            first_date = (
-                self.get_queryset()
-                .values_list("pub_date", flat=True)
-                .order_by("pub_date")[0]
+        first_date = self.get_queryset().first_pub_date()
+        if first_date is not None and first_date < self.context["day"]:
+            return reverse(
+                "mycomics_day",
+                kwargs={
+                    "year": first_date.year,
+                    "month": first_date.month,
+                    "day": first_date.day,
+                },
             )
-            if first_date < self.context["day"]:
-                return reverse(
-                    "mycomics_day",
-                    kwargs={
-                        "year": first_date.year,
-                        "month": first_date.month,
-                        "day": first_date.day,
-                    },
-                )
-        except IndexError:
-            return None
         return None
 
     def get_prev_url(self) -> str | None:
@@ -388,23 +375,16 @@ class MyComicsDayView(MyComicsMixin, ReleaseDayArchiveView):
         return None
 
     def get_last_url(self) -> str | None:
-        try:
-            last_date = (
-                self.get_queryset()
-                .values_list("pub_date", flat=True)
-                .order_by("-pub_date")[0]
+        last_date = self.get_queryset().last_pub_date()
+        if last_date is not None and last_date > self.context["day"]:
+            return reverse(
+                "mycomics_day",
+                kwargs={
+                    "year": last_date.year,
+                    "month": last_date.month,
+                    "day": last_date.day,
+                },
             )
-            if last_date > self.context["day"]:
-                return reverse(
-                    "mycomics_day",
-                    kwargs={
-                        "year": last_date.year,
-                        "month": last_date.month,
-                        "day": last_date.day,
-                    },
-                )
-        except IndexError:
-            return None
         return None
 
 
@@ -431,22 +411,15 @@ class MyComicsMonthView(MyComicsMixin, ReleaseMonthArchiveView):
     """View of releases from my comics for a given month"""
 
     def get_first_url(self) -> str | None:
-        try:
-            first_month = (
-                self.get_queryset()
-                .values_list("pub_date", flat=True)
-                .order_by("pub_date")[0]
+        first_month = self.get_queryset().first_pub_date()
+        if first_month is not None and first_month < self.context["month"]:
+            return reverse(
+                "mycomics_month",
+                kwargs={
+                    "year": first_month.year,
+                    "month": first_month.month,
+                },
             )
-            if first_month < self.context["month"]:
-                return reverse(
-                    "mycomics_month",
-                    kwargs={
-                        "year": first_month.year,
-                        "month": first_month.month,
-                    },
-                )
-        except IndexError:
-            return None
         return None
 
     def get_prev_url(self) -> str | None:
@@ -468,22 +441,15 @@ class MyComicsMonthView(MyComicsMixin, ReleaseMonthArchiveView):
         return None
 
     def get_last_url(self) -> str | None:
-        try:
-            last_month = (
-                self.get_queryset()
-                .values_list("pub_date", flat=True)
-                .order_by("-pub_date")[0]
+        last_month = self.get_queryset().last_pub_date()
+        if last_month is not None and last_month > self.context["month"]:
+            return reverse(
+                "mycomics_month",
+                kwargs={
+                    "year": last_month.year,
+                    "month": last_month.month,
+                },
             )
-            if last_month > self.context["month"]:
-                return reverse(
-                    "mycomics_month",
-                    kwargs={
-                        "year": last_month.year,
-                        "month": last_month.month,
-                    },
-                )
-        except IndexError:
-            return None
         return None
 
 
@@ -508,9 +474,7 @@ class OneComicMixin(ReleaseMixin):
 
     def get_queryset(self) -> ReleaseQuerySet:
         return (
-            Release.objects.select_related()
-            .filter(comic=self.comic)
-            .order_by("pub_date")
+            Release.objects.select_related().for_comics(self.comic).order_by("pub_date")
         )
 
     def get_object_type(self) -> str | None:
@@ -526,11 +490,7 @@ class OneComicMixin(ReleaseMixin):
 
     def _get_recent_pub_dates(self) -> list[dt.date]:
         if not hasattr(self, "_recent_pub_dates"):
-            self._recent_pub_dates = list(
-                self.get_queryset()
-                .values_list("pub_date", flat=True)
-                .order_by("-pub_date")[:2]
-            )
+            self._recent_pub_dates = self.get_queryset().last_pub_dates(2)
         return self._recent_pub_dates
 
     def get_today_url(self) -> str | None:
@@ -577,25 +537,22 @@ class OneComicMixin(ReleaseMixin):
         return f"Comics from {self.comic.name}"
 
     def get_first_url(self) -> str | None:
-        try:
-            first_date = (
-                self.get_queryset()
-                .values_list("pub_date", flat=True)
-                .order_by("pub_date")[0]
+        first_date = self.get_queryset().first_pub_date()
+        current_day = self.get_current_day()
+        if (
+            first_date is not None
+            and current_day is not None
+            and first_date < current_day
+        ):
+            return reverse(
+                "comic_day",
+                kwargs={
+                    "comic_slug": self.comic.slug,
+                    "year": first_date.year,
+                    "month": first_date.month,
+                    "day": first_date.day,
+                },
             )
-            current_day = self.get_current_day()
-            if current_day is not None and first_date < current_day:
-                return reverse(
-                    "comic_day",
-                    kwargs={
-                        "comic_slug": self.comic.slug,
-                        "year": first_date.year,
-                        "month": first_date.month,
-                        "day": first_date.day,
-                    },
-                )
-        except IndexError:
-            return None
         return None
 
     def get_prev_url(self) -> str | None:
@@ -694,23 +651,16 @@ class OneComicMonthView(OneComicMixin, ReleaseMonthArchiveView):
     """View of the releases from a single comic for a given month"""
 
     def get_first_url(self) -> str | None:
-        try:
-            first_month = (
-                self.get_queryset()
-                .values_list("pub_date", flat=True)
-                .order_by("pub_date")[0]
+        first_month = self.get_queryset().first_pub_date()
+        if first_month is not None and first_month < self.context["month"]:
+            return reverse(
+                "comic_month",
+                kwargs={
+                    "comic_slug": self.comic.slug,
+                    "year": first_month.year,
+                    "month": first_month.month,
+                },
             )
-            if first_month < self.context["month"]:
-                return reverse(
-                    "comic_month",
-                    kwargs={
-                        "comic_slug": self.comic.slug,
-                        "year": first_month.year,
-                        "month": first_month.month,
-                    },
-                )
-        except IndexError:
-            return None
         return None
 
     def get_prev_url(self) -> str | None:

--- a/src/comics/browser/views.py
+++ b/src/comics/browser/views.py
@@ -35,8 +35,8 @@ def comics_list(request: AuthenticatedHttpRequest) -> HttpResponse:
         "browser/comics_list.html",
         {
             "active": {"comics_list": True},
-            "active_comics": Comic.objects.sort_by_name().filter(active=True),
-            "inactive_comics": Comic.objects.sort_by_name().filter(active=False),
+            "active_comics": Comic.objects.active().sort_by_name(),
+            "inactive_comics": Comic.objects.inactive().sort_by_name(),
             "my_comics": request.user.comics_profile.comics.all(),
         },
     )

--- a/src/comics/browser/views.py
+++ b/src/comics/browser/views.py
@@ -315,7 +315,9 @@ class MyComicsLatestView(MyComicsMixin, ReleaseLatestView):
 
 class MyComicsNumReleasesSinceView(MyComicsLatestView):
     def get_num_releases_since(self) -> int:
-        last_release_seen = get_object_or_404(Release, id=self.kwargs["release_id"])
+        last_release_seen = get_object_or_404(
+            Release.objects.for_pk(self.kwargs["release_id"])
+        )
         releases = super().get_queryset()
         return releases.fetched_after(last_release_seen.fetched).count()
 

--- a/src/comics/browser/views.py
+++ b/src/comics/browser/views.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import render
 from django.urls import reverse
 from django.views.generic import (
     DayArchiveView,
@@ -50,9 +50,7 @@ class ComicMixin(View):
     @property
     def comic(self) -> Comic:
         if not hasattr(self, "_comic"):
-            self._comic = get_object_or_404(
-                Comic.objects.for_slug(self.kwargs["comic_slug"])
-            )
+            self._comic = Comic.objects.for_slug(self.kwargs["comic_slug"]).get_or_404()
         return self._comic
 
     def get_user(self) -> ComicsUser:
@@ -315,9 +313,9 @@ class MyComicsLatestView(MyComicsMixin, ReleaseLatestView):
 
 class MyComicsNumReleasesSinceView(MyComicsLatestView):
     def get_num_releases_since(self) -> int:
-        last_release_seen = get_object_or_404(
-            Release.objects.for_pk(self.kwargs["release_id"])
-        )
+        last_release_seen = Release.objects.for_pk(
+            self.kwargs["release_id"]
+        ).get_or_404()
         releases = super().get_queryset()
         return releases.fetched_after(last_release_seen.fetched).count()
 

--- a/src/comics/core/comic_data.py
+++ b/src/comics/core/comic_data.py
@@ -92,7 +92,7 @@ class ComicDataLoader:
         return bool(
             data.active
             or self.include_inactive
-            or Comic.objects.filter(slug=data.slug).exists()
+            or Comic.objects.for_slug(data.slug).exists()
         )
 
     def _load_data(self, data: ComicDataBase) -> None:

--- a/src/comics/core/querysets.py
+++ b/src/comics/core/querysets.py
@@ -4,8 +4,10 @@ import datetime as dt
 from typing import TYPE_CHECKING, Self, cast
 
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models.functions import Lower
+from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
 if TYPE_CHECKING:
@@ -25,6 +27,17 @@ class BaseQuerySet[M: models.Model](models.QuerySet[M]):
 
     def for_pk(self, pk: int, /) -> Self:
         return self.filter(pk=pk)
+
+    def get_or_404(self) -> M:
+        """Like get(), but raising Http404 instead of DoesNotExist."""
+        return get_object_or_404(self)
+
+    def get_or_none(self) -> M | None:
+        """Like get(), but returning None instead of raising DoesNotExist."""
+        try:
+            return self.get()
+        except ObjectDoesNotExist:
+            return None
 
 
 class ComicQuerySet(BaseQuerySet["Comic"]):

--- a/src/comics/core/querysets.py
+++ b/src/comics/core/querysets.py
@@ -9,6 +9,8 @@ from django.db.models.functions import Lower
 from django.utils import timezone
 
 if TYPE_CHECKING:
+    from django.contrib.auth.models import User
+
     from comics.core.models import Comic, Image, Release  # noqa: F401
 
 
@@ -32,6 +34,12 @@ class ComicQuerySet(BaseQuerySet["Comic"]):
     def for_slug(self, slug: str, /) -> Self:
         return self.filter(slug=slug)
 
+    def subscribed_by(self, user: User, /) -> Self:
+        return self.filter(userprofile__user=user)
+
+    def not_subscribed_by(self, user: User, /) -> Self:
+        return self.exclude(userprofile__user=user)
+
     def sort_by_name(self) -> Self:
         return self.order_by(Lower("name"))
 
@@ -51,6 +59,12 @@ class ReleaseQuerySet(BaseQuerySet["Release"]):
 
     def fetched_after(self, fetched: dt.datetime, /) -> Self:
         return self.filter(fetched__gt=fetched)
+
+    def subscribed_by(self, user: User, /) -> Self:
+        return self.filter(comic__userprofile__user=user)
+
+    def not_subscribed_by(self, user: User, /) -> Self:
+        return self.exclude(comic__userprofile__user=user)
 
     def for_feed(self) -> Self:
         """The releases recently fetched enough to be in a feed, newest first."""

--- a/src/comics/core/querysets.py
+++ b/src/comics/core/querysets.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
+import datetime as dt
 from typing import TYPE_CHECKING, Self, cast
 
+from django.conf import settings
 from django.db import models
 from django.db.models.functions import Lower
+from django.utils import timezone
 
 if TYPE_CHECKING:
-    import datetime as dt
-
     from comics.core.models import Comic, Image, Release  # noqa: F401
 
 
@@ -35,6 +36,11 @@ class ComicQuerySet(BaseQuerySet["Comic"]):
 class ReleaseQuerySet(BaseQuerySet["Release"]):
     def for_comics(self, *comics: Comic) -> Self:
         return self.filter(comic__in=comics)
+
+    def for_feed(self) -> Self:
+        """The releases recently fetched enough to be in a feed, newest first."""
+        from_time = timezone.now() - dt.timedelta(days=settings.COMICS_MAX_DAYS_IN_FEED)
+        return self.filter(fetched__gte=from_time).order_by("-fetched")
 
     def first_pub_date(self) -> dt.date | None:
         """The oldest publication date, if any releases exist."""

--- a/src/comics/core/querysets.py
+++ b/src/comics/core/querysets.py
@@ -29,6 +29,9 @@ class ComicQuerySet(BaseQuerySet["Comic"]):
     def inactive(self) -> Self:
         return self.filter(active=False)
 
+    def for_slug(self, slug: str, /) -> Self:
+        return self.filter(slug=slug)
+
     def sort_by_name(self) -> Self:
         return self.order_by(Lower("name"))
 

--- a/src/comics/core/querysets.py
+++ b/src/comics/core/querysets.py
@@ -20,6 +20,12 @@ class BaseQuerySet[M: models.Model](models.QuerySet[M]):
 
 
 class ComicQuerySet(BaseQuerySet["Comic"]):
+    def active(self) -> Self:
+        return self.filter(active=True)
+
+    def inactive(self) -> Self:
+        return self.filter(active=False)
+
     def sort_by_name(self) -> Self:
         return self.order_by(Lower("name"))
 

--- a/src/comics/core/querysets.py
+++ b/src/comics/core/querysets.py
@@ -6,6 +6,8 @@ from django.db import models
 from django.db.models.functions import Lower
 
 if TYPE_CHECKING:
+    import datetime as dt
+
     from comics.core.models import Comic, Image, Release  # noqa: F401
 
 
@@ -31,7 +33,22 @@ class ComicQuerySet(BaseQuerySet["Comic"]):
 
 
 class ReleaseQuerySet(BaseQuerySet["Release"]):
-    pass
+    def for_comics(self, *comics: Comic) -> Self:
+        return self.filter(comic__in=comics)
+
+    def first_pub_date(self) -> dt.date | None:
+        """The oldest publication date, if any releases exist."""
+        return self.values_list("pub_date", flat=True).order_by("pub_date").first()
+
+    def last_pub_date(self) -> dt.date | None:
+        """The newest publication date, if any releases exist."""
+        return self.values_list("pub_date", flat=True).order_by("-pub_date").first()
+
+    def last_pub_dates(self, count: int, /) -> list[dt.date]:
+        """The ``count`` newest publication dates, newest first."""
+        return list(
+            self.values_list("pub_date", flat=True).order_by("-pub_date")[:count]
+        )
 
 
 class ImageQuerySet(BaseQuerySet["Image"]):

--- a/src/comics/core/querysets.py
+++ b/src/comics/core/querysets.py
@@ -23,6 +23,9 @@ class BaseQuerySet[M: models.Model](models.QuerySet[M]):
         # application code interacts with.
         return cast("Self", super().as_manager())
 
+    def for_pk(self, pk: int, /) -> Self:
+        return self.filter(pk=pk)
+
 
 class ComicQuerySet(BaseQuerySet["Comic"]):
     def active(self) -> Self:
@@ -87,4 +90,8 @@ class ReleaseQuerySet(BaseQuerySet["Release"]):
 
 
 class ImageQuerySet(BaseQuerySet["Image"]):
-    pass
+    def for_comic(self, comic: Comic, /) -> Self:
+        return self.filter(comic=comic)
+
+    def for_checksum(self, checksum: str, /) -> Self:
+        return self.filter(checksum=checksum)

--- a/src/comics/core/querysets.py
+++ b/src/comics/core/querysets.py
@@ -40,6 +40,18 @@ class ReleaseQuerySet(BaseQuerySet["Release"]):
     def for_comics(self, *comics: Comic) -> Self:
         return self.filter(comic__in=comics)
 
+    def for_active_comics(self) -> Self:
+        return self.filter(comic__active=True)
+
+    def published_on(self, pub_date: dt.date, /) -> Self:
+        return self.filter(pub_date=pub_date)
+
+    def published_since(self, pub_date: dt.date, /) -> Self:
+        return self.filter(pub_date__gte=pub_date)
+
+    def fetched_after(self, fetched: dt.datetime, /) -> Self:
+        return self.filter(fetched__gt=fetched)
+
     def for_feed(self) -> Self:
         """The releases recently fetched enough to be in a feed, newest first."""
         from_time = timezone.now() - dt.timedelta(days=settings.COMICS_MAX_DAYS_IN_FEED)

--- a/src/comics/status/views.py
+++ b/src/comics/status/views.py
@@ -43,7 +43,7 @@ def status(request: HttpRequest, num_days: int = 21) -> HttpResponse:
 
     comics = cast(
         "QuerySet[StatusComic]",
-        Comic.objects.filter(active=True)
+        Comic.objects.active()
         .annotate(last_pub_date=Max("release__pub_date"))
         .order_by("last_pub_date"),
     )

--- a/src/comics/status/views.py
+++ b/src/comics/status/views.py
@@ -33,7 +33,7 @@ def status(request: HttpRequest, num_days: int = 21) -> HttpResponse:
     today = dt.date.today()
     last = today - dt.timedelta(days=num_days)
 
-    releases = Release.objects.filter(pub_date__gte=last, comic__active=True)
+    releases = Release.objects.for_active_comics().published_since(last)
     releases = releases.select_related().order_by("comic__slug").distinct()
 
     release_by_comic_and_day: dict[tuple[int, int], Release] = {}


### PR DESCRIPTION
This improves code readability and makes the code more type-safe at the same time.