### PR TITLE
Low-hanging improvements to the crawler APIs

### DIFF
--- a/docs/crawlers.md
+++ b/docs/crawlers.md
@@ -202,6 +202,8 @@ find the image URL.
         - attrs
         - content
         - contents
+        - element
+        - elements
         - remove
         - url
 

--- a/docs/crawlers.md
+++ b/docs/crawlers.md
@@ -301,6 +301,8 @@ for entry in feed.for_date(pub_date):
     options:
       heading_level: 4
       members:
+        - title
+        - link
         - summary
         - content0
         - html

--- a/src/comics/aggregator/crawler.py
+++ b/src/comics/aggregator/crawler.py
@@ -315,7 +315,6 @@ class ComicsKingdomCrawlerBase(CrawlerBase):
         url = page.src('img[id="theComicImage"]')
         if not url:
             url = page.content('meta[property="og:image"]')
-        assert url
         return CrawlerImage(url)
 
 
@@ -361,7 +360,6 @@ class CreatorsCrawlerBase(CrawlerBase):
             if release["release"] == pub_date.strftime("%Y-%m-%d"):
                 page = self.parse_page(release["url"])
                 url = page.src('img[itemprop="image"]')
-                assert url
                 return CrawlerImage(url)
 
         return None
@@ -384,7 +382,6 @@ class ComicControlCrawlerBase(CrawlerBase):
         for entry in feed.for_date(pub_date):
             page = self.parse_page(entry.link)
             url = page.src("img#cc-comic")
-            assert url
             text = page.title("img#cc-comic")
             title = re.sub(r".+? - (.+)", r"\1", entry.title)
 

--- a/src/comics/aggregator/feedparser.py
+++ b/src/comics/aggregator/feedparser.py
@@ -56,6 +56,21 @@ class Entry:
     [`content0`][comics.aggregator.feedparser.Entry.content0].
     """
 
+    title: str
+    """The entry's title.
+
+    Commonly passed straight on as the
+    [`CrawlerImage`][comics.aggregator.crawler.CrawlerImage] title.
+    """
+
+    link: str
+    """The URL of the entry, e.g. the comic's page for this release.
+
+    Typically fed to
+    [`Crawler.parse_page()`][comics.aggregator.crawler.CrawlerBase.parse_page]
+    when the feed itself doesn't hold the image.
+    """
+
     summary: LxmlParser
     """The entry's summary, with
     [`LxmlParser`][comics.aggregator.lxmlparser.LxmlParser] methods available

--- a/src/comics/aggregator/lxmlparser.py
+++ b/src/comics/aggregator/lxmlparser.py
@@ -235,14 +235,11 @@ class LxmlParser:
         return value
 
     def _get_all(self, attr: str, selector: str) -> list[str]:
-        try:
-            return [
-                self._decode(value)
-                for el in self._select_all(selector)
-                if (value := el.text_content() if attr == "text" else el.get(attr))
-            ]
-        except DoesNotExist:
-            return []
+        return [
+            self._decode(value)
+            for el in self._select_all(selector)
+            if (value := el.text_content() if attr == "text" else el.get(attr))
+        ]
 
     def _select_one(self, selector: str) -> HtmlElement | None:
         match self.root.cssselect(selector):
@@ -284,10 +281,6 @@ class LxmlParser:
 
 
 class LxmlParserException(ComicsError):
-    pass
-
-
-class DoesNotExist(LxmlParserException):
     pass
 
 

--- a/src/comics/aggregator/lxmlparser.py
+++ b/src/comics/aggregator/lxmlparser.py
@@ -236,7 +236,7 @@ class LxmlParser:
 
     def _get_all(self, attr: str, selector: str) -> list[str]:
         return [
-            self._decode(value)
+            value
             for el in self._select_all(selector)
             if (value := el.text_content() if attr == "text" else el.get(attr))
         ]
@@ -270,14 +270,6 @@ class LxmlParser:
         if len(value.strip()) == 0:
             value = "<xml />"
         return fromstring(value)
-
-    def _decode(self, value: str | bytes) -> str:
-        if isinstance(value, bytes):
-            try:
-                return value.decode("utf-8")
-            except UnicodeDecodeError:
-                return value.decode("iso-8859-1")
-        return value
 
 
 class LxmlParserException(ComicsError):

--- a/src/comics/aggregator/lxmlparser.py
+++ b/src/comics/aggregator/lxmlparser.py
@@ -31,6 +31,10 @@ class LxmlParser:
     - Plural methods, e.g.
       [`srcs()`][comics.aggregator.lxmlparser.LxmlParser.srcs], return a list
       of zero or more values.
+
+    Pass `first=True` to a singular method to take the first match in
+    document order instead of raising, for pages that legitimately match
+    several elements.
     """
 
     _retrieved_url: str | None
@@ -52,77 +56,174 @@ class LxmlParser:
             raise LxmlParserException("Parser needs URL or string to operate on")
 
     @overload
-    def href(self, selector: str, *, default: str) -> str: ...
+    def href(
+        self,
+        selector: str,
+        *,
+        default: str,
+        first: bool = False,
+    ) -> str: ...
 
     @overload
-    def href(self, selector: str, *, default: str | None = None) -> str | None: ...
+    def href(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None: ...
 
-    def href(self, selector: str, *, default: str | None = None) -> str | None:
+    def href(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None:
         """Return the `href` attribute of the element matching `selector`."""
-        return self._get_one("href", selector, default=default)
+        return self._get_one("href", selector, default=default, first=first)
 
     def hrefs(self, selector: str) -> list[str]:
         """Return the `href` attribute of the elements matching `selector`."""
         return self._get_all("href", selector)
 
     @overload
-    def src(self, selector: str, *, default: str) -> str: ...
+    def src(
+        self,
+        selector: str,
+        *,
+        default: str,
+        first: bool = False,
+    ) -> str: ...
 
     @overload
-    def src(self, selector: str, *, default: str | None = None) -> str | None: ...
+    def src(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None: ...
 
-    def src(self, selector: str, *, default: str | None = None) -> str | None:
+    def src(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None:
         """Return the `src` attribute of the element matching `selector`."""
-        return self._get_one("src", selector, default=default)
+        return self._get_one("src", selector, default=default, first=first)
 
     def srcs(self, selector: str) -> list[str]:
         """Return the `src` attribute of the elements matching `selector`."""
         return self._get_all("src", selector)
 
     @overload
-    def alt(self, selector: str, *, default: str) -> str: ...
+    def alt(
+        self,
+        selector: str,
+        *,
+        default: str,
+        first: bool = False,
+    ) -> str: ...
 
     @overload
-    def alt(self, selector: str, *, default: str | None = None) -> str | None: ...
+    def alt(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None: ...
 
-    def alt(self, selector: str, *, default: str | None = None) -> str | None:
+    def alt(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None:
         """Return the `alt` attribute of the element matching `selector`."""
-        return self._get_one("alt", selector, default=default)
+        return self._get_one("alt", selector, default=default, first=first)
 
     def alts(self, selector: str) -> list[str]:
         """Return the `alt` attribute of the elements matching `selector`."""
         return self._get_all("alt", selector)
 
     @overload
-    def title(self, selector: str, *, default: str) -> str: ...
+    def title(
+        self,
+        selector: str,
+        *,
+        default: str,
+        first: bool = False,
+    ) -> str: ...
 
     @overload
-    def title(self, selector: str, *, default: str | None = None) -> str | None: ...
+    def title(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None: ...
 
-    def title(self, selector: str, *, default: str | None = None) -> str | None:
+    def title(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None:
         """Return the `title` attribute of the element matching `selector`."""
-        return self._get_one("title", selector, default=default)
+        return self._get_one("title", selector, default=default, first=first)
 
     def titles(self, selector: str) -> list[str]:
         """Return the `title` attribute of the elements matching `selector`."""
         return self._get_all("title", selector)
 
     @overload
-    def value(self, selector: str, *, default: str) -> str: ...
+    def value(
+        self,
+        selector: str,
+        *,
+        default: str,
+        first: bool = False,
+    ) -> str: ...
 
     @overload
-    def value(self, selector: str, *, default: str | None = None) -> str | None: ...
+    def value(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None: ...
 
-    def value(self, selector: str, *, default: str | None = None) -> str | None:
+    def value(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None:
         """Return the `value` attribute of the element matching `selector`."""
-        return self._get_one("value", selector, default=default)
+        return self._get_one("value", selector, default=default, first=first)
 
     def values(self, selector: str) -> list[str]:
         """Return the `value` attribute of the elements matching `selector`."""
         return self._get_all("value", selector)
 
     @overload
-    def attr(self, attr: str, selector: str, *, default: str) -> str: ...
+    def attr(
+        self,
+        attr: str,
+        selector: str,
+        *,
+        default: str,
+        first: bool = False,
+    ) -> str: ...
 
     @overload
     def attr(
@@ -131,6 +232,7 @@ class LxmlParser:
         selector: str,
         *,
         default: str | None = None,
+        first: bool = False,
     ) -> str | None: ...
 
     def attr(
@@ -139,56 +241,106 @@ class LxmlParser:
         selector: str,
         *,
         default: str | None = None,
+        first: bool = False,
     ) -> str | None:
         """Return the given `attr` attribute of the element matching `selector`."""
-        return self._get_one(attr, selector, default=default)
+        return self._get_one(attr, selector, default=default, first=first)
 
     def attrs(self, attr: str, selector: str) -> list[str]:
         """Return the given `attr` attribute of the elements matching `selector`."""
         return self._get_all(attr, selector)
 
     @overload
-    def id(self, selector: str, *, default: str) -> str: ...
+    def id(
+        self,
+        selector: str,
+        *,
+        default: str,
+        first: bool = False,
+    ) -> str: ...
 
     @overload
-    def id(self, selector: str, *, default: str | None = None) -> str | None: ...
+    def id(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None: ...
 
-    def id(self, selector: str, *, default: str | None = None) -> str | None:
+    def id(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None:
         """Return the `id` attribute of the element matching `selector`."""
-        return self._get_one("id", selector, default=default)
+        return self._get_one("id", selector, default=default, first=first)
 
     def ids(self, selector: str) -> list[str]:
         """Return the `id` attribute of the elements matching `selector`."""
         return self._get_all("id", selector)
 
     @overload
-    def content(self, selector: str, *, default: str) -> str: ...
+    def content(
+        self,
+        selector: str,
+        *,
+        default: str,
+        first: bool = False,
+    ) -> str: ...
 
     @overload
-    def content(self, selector: str, *, default: str | None = None) -> str | None: ...
+    def content(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None: ...
 
-    def content(self, selector: str, *, default: str | None = None) -> str | None:
+    def content(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None:
         """Return the `content` attribute of the element matching `selector`."""
-        return self._get_one("content", selector, default=default)
+        return self._get_one("content", selector, default=default, first=first)
 
     def contents(self, selector: str) -> list[str]:
         """Return the `content` attribute of the elements matching `selector`."""
         return self._get_all("content", selector)
 
     @overload
-    def text(self, selector: str, *, default: str) -> str: ...
+    def text(
+        self,
+        selector: str,
+        *,
+        default: str,
+        first: bool = False,
+    ) -> str: ...
 
     @overload
-    def text(self, selector: str, *, default: str | None = None) -> str | None: ...
+    def text(
+        self,
+        selector: str,
+        *,
+        default: str | None = None,
+        first: bool = False,
+    ) -> str | None: ...
 
     def text(
         self,
         selector: str,
         *,
         default: str | None = None,
+        first: bool = False,
     ) -> str | None:
         """Return the text contained by the element matching `selector`."""
-        return self._get_one("text", selector, default=default)
+        return self._get_one("text", selector, default=default, first=first)
 
     def texts(self, selector: str) -> list[str]:
         """Return a list of the text contained by the elements matching `selector`."""
@@ -210,6 +362,7 @@ class LxmlParser:
         selector: str,
         *,
         default: str,
+        first: bool = False,
     ) -> str: ...
 
     @overload
@@ -219,6 +372,7 @@ class LxmlParser:
         selector: str,
         *,
         default: str | None = ...,
+        first: bool = False,
     ) -> str | None: ...
 
     def _get_one(
@@ -227,8 +381,9 @@ class LxmlParser:
         selector: str,
         *,
         default: str | None = None,
+        first: bool = False,
     ) -> str | None:
-        if (el := self._select_one(selector)) is None:
+        if (el := self._select_one(selector, first=first)) is None:
             return default
         if (value := el.text_content() if attr == "text" else el.get(attr)) is None:
             return default
@@ -241,11 +396,13 @@ class LxmlParser:
             if (value := el.text_content() if attr == "text" else el.get(attr))
         ]
 
-    def _select_one(self, selector: str) -> HtmlElement | None:
+    def _select_one(self, selector: str, *, first: bool = False) -> HtmlElement | None:
         match self.root.cssselect(selector):
             case []:
                 return None
             case [element]:
+                return element
+            case [element, *_] if first:
                 return element
             case elements:
                 msg = f"Selector matched {len(elements)} elements: {selector}"

--- a/src/comics/aggregator/lxmlparser.py
+++ b/src/comics/aggregator/lxmlparser.py
@@ -453,6 +453,7 @@ class LxmlParser:
         headers: dict[str, str] | None = None,
     ) -> HtmlElement:
         response = httpx.get(url, headers=headers, follow_redirects=True)
+        response.raise_for_status()
         self._retrieved_url = str(response.url)
         content = response.content.replace(b"\x00", b"")
         root = self._parse_string(content)

--- a/src/comics/aggregator/lxmlparser.py
+++ b/src/comics/aggregator/lxmlparser.py
@@ -35,6 +35,11 @@ class LxmlParser:
     Pass `first=True` to a singular method to take the first match in
     document order instead of raising, for pages that legitimately match
     several elements.
+
+    To extract several values from the same part of a document, use
+    [`element()`][comics.aggregator.lxmlparser.LxmlParser.element] or
+    [`elements()`][comics.aggregator.lxmlparser.LxmlParser.elements] to scope
+    a parser to it.
     """
 
     _retrieved_url: str | None
@@ -346,6 +351,31 @@ class LxmlParser:
         """Return a list of the text contained by the elements matching `selector`."""
         return self._get_all("text", selector)
 
+    def element(self, selector: str, *, first: bool = False) -> LxmlParser | None:
+        """Return a parser scoped to the element matching `selector`.
+
+        Selectors used on the returned parser match the element itself as
+        well as its descendants, so a scoped parser can both read the
+        element's own attributes and dig further into it:
+
+        ```python
+        for row in page.elements("tr"):
+            if row.text("td.date") != date_string:
+                continue
+            title = row.text("td.title a")
+        ```
+
+        Returns `None` if the selector doesn't match any element.
+        """
+        element = self._select_one(selector, first=first)
+        if element is None:
+            return None
+        return self._scoped(element)
+
+    def elements(self, selector: str) -> list[LxmlParser]:
+        """Return a parser scoped to each of the elements matching `selector`."""
+        return [self._scoped(element) for element in self._select_all(selector)]
+
     def remove(self, selector: str) -> None:
         """Remove the elements matching `selector` from the parsed document."""
         for element in self.root.cssselect(selector):
@@ -395,6 +425,12 @@ class LxmlParser:
             for el in self._select_all(selector)
             if (value := el.text_content() if attr == "text" else el.get(attr))
         ]
+
+    def _scoped(self, element: HtmlElement) -> LxmlParser:
+        parser = LxmlParser.__new__(LxmlParser)
+        parser._retrieved_url = self._retrieved_url
+        parser.root = element
+        return parser
 
     def _select_one(self, selector: str, *, first: bool = False) -> HtmlElement | None:
         match self.root.cssselect(selector):

--- a/src/comics/aggregator/lxmlparser.py
+++ b/src/comics/aggregator/lxmlparser.py
@@ -179,14 +179,14 @@ class LxmlParser:
     def text(self, selector: str, *, default: str) -> str: ...
 
     @overload
-    def text(self, selector: str, *, default: str | None = ...) -> str | None: ...
+    def text(self, selector: str, *, default: str | None = None) -> str | None: ...
 
     def text(
         self,
         selector: str,
         *,
         default: str | None = None,
-    ) -> list[str] | str | None:
+    ) -> str | None:
         """Return the text contained by the element matching `selector`."""
         return self._get_one("text", selector, default=default)
 

--- a/src/comics/comics/anleggsplassen.py
+++ b/src/comics/comics/anleggsplassen.py
@@ -18,7 +18,7 @@ class Crawler(CrawlerBase):
 
     def crawl(self, pub_date: dt.date) -> CrawlerResult:
         page = self.parse_page("https://www.at.no/emne/tegneserie")
-        articles = page.root.xpath('.//article[@data-section="tegneserie"]/div/a/@href')
+        articles = page.hrefs('article[data-section="tegneserie"] > div > a')
         for article in articles:
             article_page = self.parse_page(article)
             title = article_page.content('meta[name="title"]')

--- a/src/comics/comics/anleggsplassen.py
+++ b/src/comics/comics/anleggsplassen.py
@@ -36,12 +36,11 @@ class Crawler(CrawlerBase):
 
             # The comic image has no title, so select it by its container.
             # The page offers several widths, the widest one first.
-            urls = article_page.attrs(
-                "srcset", ".bodytext figure.column picture source"
+            url = article_page.attr(
+                "srcset", ".bodytext figure.column picture source", first=True
             )
-            if not urls:
+            if url is None:
                 continue
-            url = urls[0]
 
             return CrawlerImage(url, title, text)
         return None

--- a/src/comics/comics/anleggsplassen.py
+++ b/src/comics/comics/anleggsplassen.py
@@ -39,8 +39,6 @@ class Crawler(CrawlerBase):
             url = article_page.attr(
                 "srcset", ".bodytext figure.column picture source", first=True
             )
-            if url is None:
-                continue
 
             return CrawlerImage(url, title, text)
         return None

--- a/src/comics/comics/cyanideandhappiness.py
+++ b/src/comics/comics/cyanideandhappiness.py
@@ -22,8 +22,8 @@ class Crawler(CrawlerBase):
         for entry in feed.for_date(pub_date):
             page = self.parse_page(entry.link)
             # The comic is the first image on the image server
-            urls = page.srcs('img[src*="static.explosm.net"]')
-            if not urls:
+            url = page.src('img[src*="static.explosm.net"]', first=True)
+            if url is None:
                 continue
-            return CrawlerImage(urls[0], entry.title)
+            return CrawlerImage(url, entry.title)
         return None

--- a/src/comics/comics/devilbear.py
+++ b/src/comics/comics/devilbear.py
@@ -13,7 +13,6 @@ class Metadata(MetadataBase):
 
 
 class Crawler(CrawlerBase):
-    history_length_days = 0
     schedule = "Tu,We,Th,Fr"
     time_zone = "America/New_York"
 

--- a/src/comics/comics/evilinc.py
+++ b/src/comics/comics/evilinc.py
@@ -22,9 +22,8 @@ class Crawler(CrawlerBase):
         for entry in feed.for_date(pub_date):
             title = entry.title
             page = self.parse_page(entry.link)
-            img = page.root.xpath('//div[@id="unspliced-comic"]/picture/img')
-            if img is None:
+            url = page.src("div#unspliced-comic > picture > img", first=True)
+            if url is None:
                 continue
-            url = img[0].attrib["src"]
             return CrawlerImage(url, title)
         return None

--- a/src/comics/comics/gucomics.py
+++ b/src/comics/comics/gucomics.py
@@ -23,11 +23,11 @@ class Crawler(CrawlerBase):
         page_url = f"http://www.gucomics.com/{pub_date:%Y%m%d}"
         page = self.parse_page(page_url)
 
-        title = page.texts("b")[0]
+        title = page.text("b", default="", first=True)
         title = title.replace('"', "")
         title = title.strip()
 
-        text = page.texts(".main")[0]
+        text = page.text(".main", default="", first=True)
 
         #  If there is a "---", the text after is not about the comic
         text = text[: text.find("---")]

--- a/src/comics/comics/joyoftech.py
+++ b/src/comics/comics/joyoftech.py
@@ -30,10 +30,10 @@ class Crawler(CrawlerBase):
 
             page = self.parse_page(entry.link)
             # Some pages also hold a thumbnail beside the comic
-            urls = page.srcs(f'img[src="/joyoftech/joyimages/{num}.png"]')
-            if not urls:
-                urls = page.srcs(f'img[src*="/joyimages/{num}."]')
-            if not urls:
+            url = page.src(f'img[src="/joyoftech/joyimages/{num}.png"]', first=True)
+            if url is None:
+                url = page.src(f'img[src*="/joyimages/{num}."]', first=True)
+            if url is None:
                 continue
-            return CrawlerImage(urls[0], title)
+            return CrawlerImage(url, title)
         return None

--- a/src/comics/comics/joyoftech.py
+++ b/src/comics/comics/joyoftech.py
@@ -33,7 +33,5 @@ class Crawler(CrawlerBase):
             url = page.src(f'img[src="/joyoftech/joyimages/{num}.png"]', first=True)
             if url is None:
                 url = page.src(f'img[src*="/joyimages/{num}."]', first=True)
-            if url is None:
-                continue
             return CrawlerImage(url, title)
         return None

--- a/src/comics/comics/oots.py
+++ b/src/comics/comics/oots.py
@@ -18,8 +18,7 @@ class Crawler(CrawlerBase):
 
     def crawl(self, pub_date: dt.date) -> CrawlerResult:
         feed = self.parse_feed("https://www.giantitp.com/comics/oots.rss")
-        if len(feed.all()):
-            entry = feed.all()[0]
+        for entry in feed.all():
             page = self.parse_page(entry.link)
             url = page.src('img[src*="/comics/oots/"]')
             title = entry.title

--- a/src/comics/comics/optipess.py
+++ b/src/comics/comics/optipess.py
@@ -23,24 +23,21 @@ class Crawler(CrawlerBase):
         )
         date_string = pub_date.strftime("%b %-d")
 
-        post_link = archive_page.root.xpath(
-            '//td[(@class="archive-date") and '
-            f'(.="{date_string}")]/../td[@class="archive-title"]/a'
-        )
+        for row in archive_page.elements("tr"):
+            if row.text("td.archive-date") != date_string:
+                continue
 
-        if not post_link:
-            return None
-        else:
-            post_link = post_link[0]
+            title = row.text("td.archive-title a")
+            post_url = row.href("td.archive-title a")
+            if post_url is None:
+                return None
 
-        title = post_link.text
-        # Fetch the actual post
-        page = self.parse_page(post_link.get("href"))
-        img = page.root.xpath('//div[@id="comic"]/img')
-        if not img:
-            img = page.root.xpath('//div[@id="comic"]/a/img')
+            # Fetch the actual post
+            page = self.parse_page(post_url)
+            # The image is sometimes wrapped in a link
+            url = page.src("div#comic img", first=True)
+            text = page.title("div#comic img", first=True)
 
-        url = img[0].get("src")
-        text = img[0].get("title")
+            return CrawlerImage(url, title, text)
 
-        return CrawlerImage(url, title, text)
+        return None

--- a/src/comics/comics/perrybiblefellowship.py
+++ b/src/comics/comics/perrybiblefellowship.py
@@ -20,9 +20,6 @@ class Crawler(CrawlerBase):
         feed = self.parse_feed("https://pbfcomics.com/feed/")
         for entry in feed.for_date(pub_date):
             page = self.parse_page(entry.link)
-            urls = [
-                img.attrib["data-src"]
-                for img in page.root.findall('.//div[@id="comic"]/img')
-            ]
+            urls = page.attrs("data-src", "div#comic > img")
             return [CrawlerImage(url, entry.title) for url in urls]
         return None

--- a/src/comics/comics/questionablecontent.py
+++ b/src/comics/comics/questionablecontent.py
@@ -14,7 +14,6 @@ class Metadata(MetadataBase):
 
 
 class Crawler(CrawlerBase):
-    history_length_days = 0
     schedule = "Mo,Tu,We,Th,Su"
     time_zone = "America/New_York"
 

--- a/src/comics/comics/spaceavalanche.py
+++ b/src/comics/comics/spaceavalanche.py
@@ -22,10 +22,9 @@ class Crawler(CrawlerBase):
         for entry in feed.for_date(pub_date):
             if "COMIC ARCHIVE" not in entry.tags:
                 continue
-            urls = entry.content0.srcs('img[src*="/wp-content/uploads/"]')
-            if not urls:
+            url = entry.content0.src('img[src*="/wp-content/uploads/"]', first=True)
+            if url is None:
                 continue
-            url = urls[0]
             title = entry.title
             return CrawlerImage(url, title)
         return None

--- a/src/comics/comics/spaceavalanche.py
+++ b/src/comics/comics/spaceavalanche.py
@@ -23,8 +23,6 @@ class Crawler(CrawlerBase):
             if "COMIC ARCHIVE" not in entry.tags:
                 continue
             url = entry.content0.src('img[src*="/wp-content/uploads/"]', first=True)
-            if url is None:
-                continue
             title = entry.title
             return CrawlerImage(url, title)
         return None

--- a/src/comics/comics/thisishistorictimes.py
+++ b/src/comics/comics/thisishistorictimes.py
@@ -21,9 +21,9 @@ class Crawler(CrawlerBase):
         for entry in feed.for_date(pub_date):
             page = self.parse_page(entry.link)
             # The comic is the first image, followed by unrelated ones
-            urls = page.srcs('img[src*="/wp-content/uploads/"]')
-            if not urls:
+            url = page.src('img[src*="/wp-content/uploads/"]', first=True)
+            if url is None:
                 continue
             title = entry.title
-            return CrawlerImage(urls[0], title)
+            return CrawlerImage(url, title)
         return None

--- a/src/comics/comics/wulffmorgenthaler.py
+++ b/src/comics/comics/wulffmorgenthaler.py
@@ -20,7 +20,7 @@ class Crawler(CrawlerBase):
     def crawl(self, pub_date: dt.date) -> CrawlerResult:
         page_url = f"http://wumo.com/wumo/{pub_date:%Y/%m/%d}"
         page = self.parse_page(page_url)
-        urls = page.srcs(f'img[src*="/img/wumo/{pub_date:%Y/%m}"]')
-        if not urls:
+        url = page.src(f'img[src*="/img/wumo/{pub_date:%Y/%m}"]', first=True)
+        if url is None:
             return None
-        return CrawlerImage(urls[0])
+        return CrawlerImage(url)


### PR DESCRIPTION
Low-hanging improvements to the crawler APIs, found by reading `LxmlParser`,
`FeedParser` and all 60 hand-written `crawl()` implementations. One commit per
change, so they can be reviewed or dropped individually.

**Dead code and wrong types in `LxmlParser`**

- `DoesNotExist` was raised nowhere, so the handler wrapping `_get_all()` could
  never run. Both are gone.
- `_decode()` could never take its bytes branch, as lxml returns `str` from both
  `Element.get()` and `text_content()`. That it was applied in `_get_all()` but
  not `_get_one()` showed nothing depended on it.
- `text()` was annotated as returning `list[str] | str | None`, while its
  overloads and `_get_one()` only ever produce `str | None`.

**Errors that were classified wrong**

- The three shared base crawlers asserted the parser had found an image URL,
  preempting the `ImageURLNotFound` that `add_image()` raises. That turned a
  `CrawlerBroken` naming the comic and date into a bare `AssertionError` in the
  catch-all, and would vanish under `python -O`.
- `LxmlParser` fetched pages without checking the status, so an error page was
  parsed as if it were the comic's page. Finding no image in it, a crawler
  reported "no release found" — which is what a day the comic did not publish on
  looks like — so a site that moved or started refusing us stayed invisible.
- Three crawlers that already establish the entry is the comic, by its link,
  tags or publishing date, skipped to the next entry when the image selector
  then found nothing. They now let the empty URL reach `CrawlerImage`, which
  reports `ImageURLNotFound` at error level.

**Two additions that shrink the crawlers**

- `first=True` on the singular accessors takes the first match in document order
  instead of raising `MultipleElementsReturned`. Pages that legitimately match
  several had to fall back to the plural accessor and index into it, guarding the
  empty list by hand. Seven crawlers move over.
- `element()` / `elements()` return parsers scoped to the matching elements, for
  crawlers that need to pick a container and then read its children. Four
  crawlers come off `page.root`, where they hand-rolled the extraction and lost
  the default handling, the multiple-match guard and the CSS selectors. This also
  fixes a latent bug in the Evil Inc crawler, which tested `xpath()` against
  `None` while it returns an empty list.

  Awkward Zombie and Subnormality keep using `page.root`: they match on element
  text and sort by a parsed `style` attribute, which the selector API does not
  express.

**Smaller things**

- `Entry.title` and `Entry.link` reach crawlers through `__getattr__`, so they
  typed as `Any` and nothing checked their use in the 41 feed crawlers. Declared
  alongside the existing `summary` and `content0` annotations.
- The OOTS crawler called `feed.all()` twice, rebuilding the entry list to test
  for and then take the first entry.
- `history_length_days = 0` resolves to the same `history_start` as leaving both
  history attributes out, which already means only today can be crawled.

**Worth watching after deploy**

`raise_for_status()` is the one change that can turn a working crawler into a
failing one, if a site serves usable content with a non-2xx status. I checked the
crawlers that mention HTTP status: Penny Arcade's soft-404 comes with a 200 and
is unaffected, Dumbing of Age's 404 note is about the image server on the
downloader path, and Buttersafe's User-Agent dodges a 403 that would now surface
as a warning instead of being parsed silently.

**Not touched, but the same shape**

- Wumo's guard is now safe to drop too, since a gone page raises rather than
  falling through.
- `CreatorsCrawlerBase` also calls `httpx.get()` without a status check and then
  `.json()`, so a non-2xx fails as a JSON decode error and lands in the catch-all
  rather than as a `CrawlerHTTPError`.

`LxmlParser` and `FeedParser` have no tests, so the new `first=True` and
`elements()` surface ships unit-tested only by hand against sample markup.

https://claude.ai/code/session_013DLpoXp8z36AGE2ksWG58n
